### PR TITLE
ci: update .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -10,12 +10,6 @@
         "githubUrl": "https://github.com",
         "githubApiPathPrefix": "/api/v3"
       }
-    ],
-    [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "./ci/publish-go-module.sh v${nextRelease.version}"
-      }
     ]
   ]
 }


### PR DESCRIPTION
### Description

Remove the call to `./ci/publish-go-module.sh` inside `.releaserc` as this was only used for internal publishing

**Tick the relevant boxes:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc)

### Checklist:

- [ ] The PR is referencing a github issue.
- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
