### PR TITLE
ci: set up git submodule with https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common-dev-assets"]
 	path = common-dev-assets
-	url = git@github.com:terraform-ibm-modules/common-dev-assets.git
+	url = https://github.com/terraform-ibm-modules/common-dev-assets.git


### PR DESCRIPTION
### Description

set up git submodule with https instead of ssh for consistency with terraform module repos

**Tick the relevant boxes:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc)

### Checklist:

- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
