### PR TITLE
fix: use origin when checking git log commit messages

### DIFF
--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -23,7 +23,9 @@ import (
 
 func skipUpgradeTest(branch string) bool {
 	// Get all the commit messages from the PR branch
-	cmd := exec.Command("/bin/sh", "-c", "git log master..", branch)
+	// NOTE: using the "origin" of the default branch as the start point, which will exist in a fresh
+	// clone even if the default branch has not been checked out or pulled.
+	cmd := exec.Command("/bin/sh", "-c", "git log origin/master..", branch)
 	out, _ := cmd.CombinedOutput()
 
 	// Skip upgrade Test if BREAKING CHANGE OR SKIP UPGRADE TEST string found in commit messages
@@ -32,7 +34,9 @@ func skipUpgradeTest(branch string) bool {
 		doNotRunUpgradeTest = true
 	}
 	if !doNotRunUpgradeTest {
-		cmd = exec.Command("/bin/sh", "-c", "git log main..", branch)
+		// NOTE: using the "origin" of the default branch as the start point, which will exist in a fresh
+		// clone even if the default branch has not been checked out or pulled.
+		cmd = exec.Command("/bin/sh", "-c", "git log origin/main..", branch)
 		out, _ = cmd.CombinedOutput()
 
 		if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") {


### PR DESCRIPTION
### Description

Use origin/main or origin/master when checking git logs for commit messages. This fixes a bug where a repo was cloned by the CI process and has never pulled the main or master branch into a local branch, but the initial fetch does have a tracking branch which will always exist.

**Tick the relevant boxes:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc)

### Checklist:

- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
