### PR TITLE
fix: Make passing of resource group conditional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,6 @@ terraform.rc
 
 # Ignore .tfsec
 .tfsec/
+
+# vscode
+.vscode/

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -45,12 +45,16 @@ func TestOptionsDefaultWithVars(originalOptions *TestOptions) *TestOptions {
 	newOptions := TestOptionsDefault(originalOptions)
 
 	// Vars to pass into module
-	newOptions.TerraformVars = mergeMaps(map[string]interface{}{
-		"prefix":         newOptions.Prefix,
-		"region":         newOptions.Region,
-		"resource_group": newOptions.ResourceGroup,
-		"resource_tags":  GetTagsFromTravis(),
-	}, newOptions.TerraformVars)
+	varsMap := make(map[string]interface{})
+
+	conditionalAdd(varsMap, "prefix", newOptions.Prefix, "")
+	conditionalAdd(varsMap, "region", newOptions.Region, "")
+	conditionalAdd(varsMap, "resource_group", newOptions.ResourceGroup, "")
+
+	varsMap["resource_tags"] = GetTagsFromTravis()
+
+	// Vars to pass into module
+	newOptions.TerraformVars = mergeMaps(varsMap, newOptions.TerraformVars)
 
 	return newOptions
 
@@ -118,4 +122,11 @@ func mergeMaps(maps ...map[string]interface{}) map[string]interface{} {
 		}
 	}
 	return result
+}
+
+// Adds value to map[key] only if value != compareValue
+func conditionalAdd(amap map[string]interface{}, key string, value string, compareValue string) {
+	if value != compareValue {
+		amap[key] = value
+	}
 }


### PR DESCRIPTION
### Description

Some modules such as the landing-zone module do not require a resource group to be passed as input. This change in the wrapper make it conditional.

**Tick the relevant boxes:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc)

### Checklist:

- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
