### PR TITLE
fix: use git hash for upgrade test checkouts

### DIFF
--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -199,7 +199,7 @@ func (options *TestOptions) RunTestUpgrade() (*terraform.PlanStruct, error) {
 		}
 
 		opts := &git.FetchOptions{
-			RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+			RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 		}
 
 		if err := remote.Fetch(opts); err != nil {


### PR DESCRIPTION
### Description

It was discovered during automated pipeline tests that the `RunTestUpgrade()` function was not switching back to the PR branch to do the final `terraform plan` step, and would instead stay on the master/main branch, which makes the test invalid.

This PR contains two fixes for this scenario:
1. Will use the original branch commit HASH, instead of the original branch name, to make absolutely sure that the final `git checkout` will point to the original code before running the final `plan` step of the upgrade test.
2. Remove the `git fetch` of "refs/heads/HEAD" as this was causing a local branch named "HEAD" and causing a warning in git operations inside the upgrade test due to ambiguous references to HEAD. Testing has shown that this additional fetch was not needed for this function.

Using the git commit hash for the final checkout does have some consequences:
If the original branch was an actual branch (and not a PR pseudo merge reference), the final checkout to the hash of that original branch will result in a "detached head" status in git, which is a little different than the original status.
I do not think this will be an issue because terratest-wrapper will perform all of the upgrade checkouts in a temporary directory which is discarded, and will not affect the original clone.

**Tick the relevant boxes:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples / tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc)

### Checklist:

- [ ] If relevant, a test for the change has been added / updated as part of this PR.
- [ ] If relevant, documentation for the change has been added / updated as part of this PR.

### Merge:
Merge using "Squash and merge" and ensure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message based on the PR contents (this ultimately determines if a new version of the modules needs to be released, and if so, which semver number should be used).
