### PR TITLE
fix: remove init for optional upgrade step

### DIFF
--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -278,7 +278,7 @@ func (options *TestOptions) RunTestUpgrade() (*terraform.PlanStruct, error) {
 					// Adding optional upgrade support on PR Branch
 					if options.CheckApplyResultForUpgrade && !options.Testing.Failed() {
 						logger.Log(options.Testing, "Validating Optional upgrade on Current Branch (PR):", cur.Name())
-						_, resultErr = terraform.InitAndApplyE(options.Testing, options.TerraformOptions)
+						_, resultErr = terraform.ApplyE(options.Testing, options.TerraformOptions)
 						assert.Nilf(options.Testing, resultErr, "Terraform Apply on PR branch has failed")
 					}
 				} else {


### PR DESCRIPTION
### Description

Changed InitAndApply() to Apply() for the optional last step of Upgrade test, fixes kubecontrol missing issues after branch checkout.

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Removing the `init` step of the final optional apply task of the upgrade test, which was removing any kube files generated by the previous `plan` step resulting in error (missing kubeconfig).

---

### Checklist for reviewers

- [x] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
