### PR TITLE
fix: issues with schematics api calls and tar creation

### DIFF
--- a/common/general.go
+++ b/common/general.go
@@ -164,3 +164,14 @@ func StrArrayContains(arr []string, val string) bool {
 
 	return false
 }
+
+// IntArrayContains is a helper function that will check an array and see if an int value is already present
+func IntArrayContains(arr []int, val int) bool {
+	for _, arrVal := range arr {
+		if arrVal == val {
+			return true
+		}
+	}
+
+	return false
+}

--- a/testschematic/mock_test.go
+++ b/testschematic/mock_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const mockWorkspaceID = "ws12345"
+const mockWorkspaceName = "NewWorkspace-12345"
 const mockTemplateID = "template54321"
 const mockActivityID = "activity98765"
 const mockPlanID = "plan123"
@@ -74,11 +75,12 @@ func mockSchematicServiceReset(mock *schematicServiceMock, options *TestSchemati
 // SCHEMATIC SERVICE MOCK FUNCTIONS
 func (mock *schematicServiceMock) CreateWorkspace(createWorkspaceOptions *schematics.CreateWorkspaceOptions) (*schematics.WorkspaceResponse, *core.DetailedResponse, error) {
 	if mock.failCreateWorkspace {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 
 	result := &schematics.WorkspaceResponse{
-		ID: core.StringPtr(mockWorkspaceID),
+		ID:   core.StringPtr(mockWorkspaceID),
+		Name: core.StringPtr(mockWorkspaceName),
 		TemplateData: []schematics.TemplateSourceDataResponse{
 			{ID: core.StringPtr(mockTemplateID)},
 		},
@@ -89,7 +91,7 @@ func (mock *schematicServiceMock) CreateWorkspace(createWorkspaceOptions *schema
 
 func (mock *schematicServiceMock) UpdateWorkspace(updateWorkspaceOptions *schematics.UpdateWorkspaceOptions) (*schematics.WorkspaceResponse, *core.DetailedResponse, error) {
 	if mock.failCreateWorkspace {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 
 	result := &schematics.WorkspaceResponse{
@@ -104,7 +106,7 @@ func (mock *schematicServiceMock) UpdateWorkspace(updateWorkspaceOptions *schema
 
 func (mock *schematicServiceMock) DeleteWorkspace(deleteWorkspaceOptions *schematics.DeleteWorkspaceOptions) (*string, *core.DetailedResponse, error) {
 	if mock.failDeleteWorkspace {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := core.StringPtr("deleted")
 	response := &core.DetailedResponse{StatusCode: 200}
@@ -114,7 +116,7 @@ func (mock *schematicServiceMock) DeleteWorkspace(deleteWorkspaceOptions *schema
 
 func (mock *schematicServiceMock) TemplateRepoUpload(templateRepoUploadOptions *schematics.TemplateRepoUploadOptions) (*schematics.TemplateRepoTarUploadResponse, *core.DetailedResponse, error) {
 	if mock.failTemplateRepoUpload {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := &schematics.TemplateRepoTarUploadResponse{
 		ID: core.StringPtr(mockWorkspaceID),
@@ -125,7 +127,7 @@ func (mock *schematicServiceMock) TemplateRepoUpload(templateRepoUploadOptions *
 
 func (mock *schematicServiceMock) ReplaceWorkspaceInputs(replaceWorkspaceInputsOptions *schematics.ReplaceWorkspaceInputsOptions) (*schematics.UserValues, *core.DetailedResponse, error) {
 	if mock.failReplaceWorkspaceInputs {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := &schematics.UserValues{
 		Variablestore: []schematics.WorkspaceVariableResponse{},
@@ -136,7 +138,7 @@ func (mock *schematicServiceMock) ReplaceWorkspaceInputs(replaceWorkspaceInputsO
 
 func (mock *schematicServiceMock) ListWorkspaceActivities(listWorkspaceactivitiesOptions *schematics.ListWorkspaceActivitiesOptions) (*schematics.WorkspaceActivities, *core.DetailedResponse, error) {
 	if mock.failListWorkspaceActivities {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	var result *schematics.WorkspaceActivities
 	if mock.emptyListWorkspaceActivities {
@@ -165,11 +167,11 @@ func (mock *schematicServiceMock) ListWorkspaceActivities(listWorkspaceactivitie
 
 func (mock *schematicServiceMock) GetWorkspaceActivity(getWorkspaceActivityOptions *schematics.GetWorkspaceActivityOptions) (*schematics.WorkspaceActivity, *core.DetailedResponse, error) {
 	if mock.failGetWorkspaceActivity {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 
 	if getWorkspaceActivityOptions.WID == nil || getWorkspaceActivityOptions.ActivityID == nil {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 
 	var result *schematics.WorkspaceActivity
@@ -198,7 +200,7 @@ func (mock *schematicServiceMock) findActivity(id string) *schematics.WorkspaceA
 
 func (mock *schematicServiceMock) PlanWorkspaceCommand(planWorkspaceCommandOptions *schematics.PlanWorkspaceCommandOptions) (*schematics.WorkspaceActivityPlanResult, *core.DetailedResponse, error) {
 	if mock.failPlanWorkspaceCommand {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := &schematics.WorkspaceActivityPlanResult{
 		Activityid: core.StringPtr(mockPlanID),
@@ -209,7 +211,7 @@ func (mock *schematicServiceMock) PlanWorkspaceCommand(planWorkspaceCommandOptio
 
 func (mock *schematicServiceMock) ApplyWorkspaceCommand(applyWorkspaceCommandOptions *schematics.ApplyWorkspaceCommandOptions) (*schematics.WorkspaceActivityApplyResult, *core.DetailedResponse, error) {
 	if mock.failApplyWorkspaceCommand {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := &schematics.WorkspaceActivityApplyResult{
 		Activityid: core.StringPtr(mockApplyID),
@@ -221,7 +223,7 @@ func (mock *schematicServiceMock) ApplyWorkspaceCommand(applyWorkspaceCommandOpt
 
 func (mock *schematicServiceMock) DestroyWorkspaceCommand(destroyWorkspaceCommandOptions *schematics.DestroyWorkspaceCommandOptions) (*schematics.WorkspaceActivityDestroyResult, *core.DetailedResponse, error) {
 	if mock.failDestroyWorkspaceCommand {
-		return nil, nil, &schematicErrorMock{}
+		return nil, &core.DetailedResponse{StatusCode: 404}, &schematicErrorMock{}
 	}
 	result := &schematics.WorkspaceActivityDestroyResult{
 		Activityid: core.StringPtr(mockDestroyID),

--- a/testschematic/schematics.go
+++ b/testschematic/schematics.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -378,7 +377,7 @@ func (svc *SchematicsTestService) WaitForFinalJobStatus(jobID string) (string, e
 		}
 		// only log svc once a minute or so
 		if runMinutes > lastLog {
-			log.Printf("[SCHEMATICS] ... still waiting for job %s to complete: %d minutes", *job.Name, runMinutes)
+			svc.TestOptions.Testing.Logf("[SCHEMATICS] ... still waiting for job %s to complete: %d minutes", *job.Name, runMinutes)
 			lastLog = runMinutes
 		}
 
@@ -387,7 +386,7 @@ func (svc *SchematicsTestService) WaitForFinalJobStatus(jobID string) (string, e
 			len(*job.Status) > 0 &&
 			*job.Status != SchematicsJobStatusCreated &&
 			*job.Status != SchematicsJobStatusInProgress {
-			log.Printf("[SCHEMATICS] The status of job %s is: %s", *job.Name, *job.Status)
+			svc.TestOptions.Testing.Logf("[SCHEMATICS] The status of job %s is: %s", *job.Name, *job.Status)
 			break
 		}
 

--- a/testschematic/schematics.go
+++ b/testschematic/schematics.go
@@ -716,7 +716,7 @@ func (svc *SchematicsTestService) retryApiCall(apiError error, apiStatusCode int
 		maxRetries = *svc.TestOptions.SchematicSvcRetryCount
 	}
 	if svc.TestOptions.SchematicSvcRetryWaitSeconds != nil {
-		maxRetries = *svc.TestOptions.SchematicSvcRetryWaitSeconds
+		maxWait = *svc.TestOptions.SchematicSvcRetryWaitSeconds
 	}
 
 	// if we are at our max retry count, do not retry

--- a/testschematic/schematics_test.go
+++ b/testschematic/schematics_test.go
@@ -46,14 +46,18 @@ func TestSchematicTarCreation(t *testing.T) {
 }
 
 func TestSchematicCreateWorkspace(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	svc := &SchematicsTestService{
 		SchematicsApiSvc: schematicSvc,
 		TestOptions: &TestSchematicOptions{
+			Testing: new(testing.T),
 			RequiredEnvironmentVars: map[string]string{
 				"GIT_TOKEN_USER": "tester",   // pragma: allowlist secret
 				"GIT_TOKEN":      "99999999", // pragma: allowlist secret
 			},
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
 		},
 	}
 	mockErrorType := new(schematicErrorMock)
@@ -80,11 +84,17 @@ func TestSchematicCreateWorkspace(t *testing.T) {
 }
 
 func TestSchematicUpdateWorkspace(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	svc := &SchematicsTestService{
 		SchematicsApiSvc: schematicSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 	vars := []TestSchematicTerraformVar{
@@ -121,11 +131,17 @@ func TestSchematicUpdateWorkspace(t *testing.T) {
 }
 
 func TestUploadSchematicTarFile(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	svc := &SchematicsTestService{
 		SchematicsApiSvc: schematicSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	pathError := new(os.PathError)
 	mockErrorType := new(schematicErrorMock)
@@ -157,6 +173,7 @@ func TestUploadSchematicTarFile(t *testing.T) {
 }
 
 func TestSchematicCreatePlanJob(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -164,6 +181,11 @@ func TestSchematicCreatePlanJob(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -182,6 +204,7 @@ func TestSchematicCreatePlanJob(t *testing.T) {
 }
 
 func TestSchematicCreateApplyJob(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -189,6 +212,11 @@ func TestSchematicCreateApplyJob(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -208,6 +236,7 @@ func TestSchematicCreateApplyJob(t *testing.T) {
 }
 
 func TestSchematicCreateDestroyJob(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -215,6 +244,11 @@ func TestSchematicCreateDestroyJob(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -234,6 +268,7 @@ func TestSchematicCreateDestroyJob(t *testing.T) {
 }
 
 func TestSchematicFindJob(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -241,6 +276,11 @@ func TestSchematicFindJob(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 	notFoundErrorType := errors.NotFound("mock")
@@ -289,6 +329,7 @@ func TestSchematicFindJob(t *testing.T) {
 }
 
 func TestSchematicGetJobDetail(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -296,6 +337,11 @@ func TestSchematicGetJobDetail(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -319,6 +365,7 @@ func TestSchematicGetJobDetail(t *testing.T) {
 }
 
 func TestSchematicDeleteWorkspace(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -326,6 +373,11 @@ func TestSchematicDeleteWorkspace(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -345,6 +397,7 @@ func TestSchematicDeleteWorkspace(t *testing.T) {
 }
 
 func TestSchematicWaitForJobFinish(t *testing.T) {
+	zero := 0
 	schematicSvc := new(schematicServiceMock)
 	authSvc := new(iamAuthenticatorMock)
 	svc := &SchematicsTestService{
@@ -352,6 +405,11 @@ func TestSchematicWaitForJobFinish(t *testing.T) {
 		ApiAuthenticator: authSvc,
 		WorkspaceID:      mockWorkspaceID,
 		TemplateID:       mockTemplateID,
+		TestOptions: &TestSchematicOptions{
+			Testing:                      new(testing.T),
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		},
 	}
 	mockErrorType := new(schematicErrorMock)
 
@@ -369,5 +427,64 @@ func TestSchematicWaitForJobFinish(t *testing.T) {
 		schematicSvc.failGetWorkspaceActivity = true
 		_, err := svc.WaitForFinalJobStatus(mockActivityID)
 		assert.ErrorAs(t, err, &mockErrorType)
+	})
+}
+
+func TestSchematicApiRetry(t *testing.T) {
+	retry := 1
+	svc := &SchematicsTestService{
+		TestOptions: &TestSchematicOptions{
+			SchematicSvcRetryCount:       &retry,
+			SchematicSvcRetryWaitSeconds: &retry,
+		},
+	}
+
+	testErr := errors.NotFound("not found")
+
+	t.Run("NoErrorNoRetry", func(t *testing.T) {
+		wasRetry := svc.retryApiCall(nil, 200, 0)
+		assert.False(t, wasRetry)
+	})
+
+	t.Run("ErrorMaxRetries", func(t *testing.T) {
+		wasRetry := svc.retryApiCall(testErr, 404, 1)
+		assert.False(t, wasRetry)
+	})
+
+	t.Run("RetryOnError", func(t *testing.T) {
+		wasRetry := svc.retryApiCall(testErr, 404, 0)
+		assert.True(t, wasRetry)
+	})
+
+	t.Run("ErrorNoRetryException", func(t *testing.T) {
+		wasRetry := svc.retryApiCall(testErr, getApiRetryStatusExceptions()[0], 0)
+		assert.False(t, wasRetry)
+	})
+
+	t.Run("VerifyDefaultUsed", func(t *testing.T) {
+		zero := 0
+		svc.TestOptions = &TestSchematicOptions{
+			SchematicSvcRetryWaitSeconds: &zero,
+		}
+		loops := 0
+		for {
+			wasRetry := svc.retryApiCall(testErr, 404, loops)
+			if wasRetry {
+				loops++
+			} else {
+				break
+			}
+		}
+		assert.Equal(t, defaultApiRetryCount, loops)
+	})
+
+	t.Run("VerifyCanTurnOffRetry", func(t *testing.T) {
+		zero := 0
+		svc.TestOptions = &TestSchematicOptions{
+			SchematicSvcRetryCount:       &zero,
+			SchematicSvcRetryWaitSeconds: &zero,
+		}
+		wasRetry := svc.retryApiCall(testErr, 404, 0)
+		assert.False(t, wasRetry)
 	})
 }

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -111,6 +111,16 @@ type TestSchematicOptions struct {
 	CloudInfoService  cloudinfo.CloudInfoServiceI // OPTIONAL: Supply if you need multiple tests to share info service and data
 	SchematicsApiSvc  SchematicsApiSvcI           // OPTIONAL: service pointer for interacting with external schematics api
 	schematicsTestSvc *SchematicsTestService      // internal property to specify pointer to test service, used for test mocking
+
+	// These optional fields can be used to override the default retry settings for making Schematics API calls.
+	// If SDK/API calls to Schematics result in errors, such as retrieving existing workspace details,
+	// the test framework will retry those calls for a set number of times, with a wait time between calls.
+	//
+	// NOTE: these are pointers to int, so that we know they were purposly set (they are nil), as zero is a legitimate value
+	//
+	// Current Default: 5 retries, 5 second wait
+	SchematicSvcRetryCount       *int
+	SchematicSvcRetryWaitSeconds *int
 }
 
 type TestSchematicTerraformVar struct {

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -19,7 +19,7 @@ const defaultRegionYaml = "../common-dev-assets/common-go-assets/cloudinfo-regio
 const ibmcloudApiKeyVar = "TF_VAR_ibmcloud_api_key"
 const defaultGitUserEnvKey = "GIT_TOKEN_USER"
 const defaultGitTokenEnvKey = "GIT_TOKEN"
-const DefaultWaitJobCompleteMinutes = int16(120) // default 2 hrs wait time
+const DefaultWaitJobCompleteMinutes = int16(240) // default 4 hrs wait time
 const DefaultSchematicsApiURL = "https://schematics.cloud.ibm.com"
 
 // TestSchematicOptions is the main data struct containing all options related to running a Terraform unit test wihtin IBM Schematics Workspaces

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -44,6 +44,16 @@ type TestSchematicOptions struct {
 	CloudInfoService        cloudinfo.CloudInfoServiceI    // OPTIONAL: Supply if you need multiple tests to share info service and data
 	SchematicsApiSvc        SchematicsApiSvcI              // OPTIONAL: service pointer for interacting with external schematics api
 	schematicsTestSvc       *SchematicsTestService         // OPTIONAL: internal property to specify pointer to test service, used for test mocking
+
+	// These optional fields can be used to override the default retry settings for making Schematics API calls.
+	// If SDK/API calls to Schematics result in errors, such as retrieving existing workspace details,
+	// the test framework will retry those calls for a set number of times, with a wait time between calls.
+	//
+	// NOTE: these are pointers to int, so that we know they were purposly set (they are nil), as zero is a legitimate value
+	//
+	// Current Default: 5 retries, 5 second wait
+	SchematicSvcRetryCount       *int
+	SchematicSvcRetryWaitSeconds *int
 }
 
 type TestSchematicTerraformVar struct {

--- a/testschematic/tests_test.go
+++ b/testschematic/tests_test.go
@@ -21,6 +21,7 @@ func TestSchematicFullTest(t *testing.T) {
 		TemplateID:       mockTemplateID,
 	}
 	//mockErrorType := new(schematicv1ErrorMock)
+	zero := 0
 
 	options := &TestSchematicOptions{
 		Testing:                 new(testing.T),
@@ -32,12 +33,14 @@ func TestSchematicFullTest(t *testing.T) {
 			{Name: "var1", Value: "val1", DataType: "string", Secure: false},
 			{Name: "var2", Value: "val2", DataType: "string", Secure: false},
 		},
-		Tags:                   []string{"unit-test"},
-		TarIncludePatterns:     []string{"*.md"},
-		WaitJobCompleteMinutes: 1,
-		DeleteWorkspaceOnFail:  false,
-		SchematicsApiSvc:       schematicSvc,
-		schematicsTestSvc:      svc,
+		Tags:                         []string{"unit-test"},
+		TarIncludePatterns:           []string{"*.md"},
+		WaitJobCompleteMinutes:       1,
+		DeleteWorkspaceOnFail:        false,
+		SchematicsApiSvc:             schematicSvc,
+		schematicsTestSvc:            svc,
+		SchematicSvcRetryCount:       &zero,
+		SchematicSvcRetryWaitSeconds: &zero,
 	}
 
 	// mock at least one good tar upload and one other completed activity


### PR DESCRIPTION
### Description

Fixes for several issues relating to recently added IBM Cloud Schematics test framework.
- Fix TAR file creation, do not use `os.Chdir()` which is not thread-safe
- Add retry mechanic to all Schematics SDK calls
- Logging of Schematic Workspace name in errors and test fail assertions

### Types of changes in this PR
Bug fixes and minor enhancements

#### No release required

- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Fixes for several issues relating to recently added IBM Cloud Schematics test framework.
- Fix TAR file creation, do not use `os.Chdir()` which is not thread-safe
- Add retry mechanic to all Schematics SDK calls
- Logging of Schematic Workspace name in errors and test fail assertions

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
