### PR TITLE
feat: output human-readable change log

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-29T00:17:19Z",
+  "generated_at": "2023-05-17T11:30:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -152,7 +152,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.59.dss",
+  "version": "0.13.1+ibm.60.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -61,9 +61,6 @@ func (options *TestOptions) checkConsistency(plan *terraform.PlanStruct) {
 			changesJson = string(changesBytes)
 		}
 
-		// Run plan again to output the nice human-readable plan
-		//terraform.Plan(options.Testing, options.TerraformOptions)
-
 		var resourceDetails string
 
 		if resource.Change.Actions.Update() {


### PR DESCRIPTION
### Description

It can be hard to see the reason why a resource has been changed when the consistency test fails. The Terraform CLI renders this nicely but because we are running plan with struct so we can ignore certain changes we loose the formatted output. I investigated implementing the code from the Terraform CLI to render for humans however it was too complex. Instead, if there is a valid change I re-run the plan but in the basic mode that uses the CLI output.

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [x] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
