### PR TITLE
feat: add common function to generate test SSH Public Key

### DIFF
--- a/common/general_test.go
+++ b/common/general_test.go
@@ -215,3 +215,12 @@ func TestLoadMapFromYaml(t *testing.T) {
 		}
 	})
 }
+
+func TestGenerateSshPublicKey(t *testing.T) {
+	newKey, err := GenerateSshRsaPublicKey()
+	assert.NoErrorf(t, err, "Failed to create key: %v", err)
+	if assert.NotEmpty(t, newKey) {
+		// make sure there are no newlines
+		assert.NotContains(t, newKey, "\n")
+	}
+}


### PR DESCRIPTION
### Description

Added new public function under `common` package to generate a new RSA keypair, and return the Public Key in OpenSSH Authorized Key format.

This new function can be used to generate throw-away public keys for use in test inputs.

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [x] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added new function: `common.GenerateSshRsaPublicKey`
This function will generate a new RSA public key and return it in OpenSSH format. Can be used to generate throw-away (but valid) public keys in test inputs.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
