### PR TITLE
fix: add logging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-08-17T15:11:46Z",
+  "generated_at": "2023-08-23T12:30:38Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -138,7 +138,7 @@
         "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 313,
+        "line_number": 324,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -146,7 +146,7 @@
         "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 325,
+        "line_number": 337,
         "type": "Secret Keyword",
         "verified_result": null
       }


### PR DESCRIPTION
### Description

Adding extra logging for validation in pipeline

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
