### PR TITLE
add cbr cleanup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-15T09:55:15Z",
+  "generated_at": "2023-09-28T14:28:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -100,7 +100,7 @@
         "hashed_secret": "892bd503fb45f6fcafb1c7003d88291fc0b20208",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 151,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -108,7 +108,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 229,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -138,7 +138,7 @@
         "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 401,
+        "line_number": 426,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -146,7 +146,7 @@
         "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 439,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/cloudinfo/cbr.go
+++ b/cloudinfo/cbr.go
@@ -2,26 +2,27 @@ package cloudinfo
 
 import (
 	"fmt"
+	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/contextbasedrestrictionsv1"
 )
 
 // GetCBRRuleByID gets a rule by its ID using the Context-based Restrictions service
-func (infoSvc *CloudInfoService) GetCBRRuleByID(ruleID string) (*contextbasedrestrictionsv1.Rule, error) {
+func (infoSvc *CloudInfoService) GetCBRRuleByID(ruleID string) (*contextbasedrestrictionsv1.Rule, *core.DetailedResponse, error) {
 	// Call the GetRule method with the rule ID and the context
 	getRuleOptions := &contextbasedrestrictionsv1.GetRuleOptions{
 		RuleID: &ruleID,
 	}
-	rule, response, err := infoSvc.cbrService.GetRule(getRuleOptions)
+	rule, detailedResponse, err := infoSvc.cbrService.GetRule(getRuleOptions)
 	if err != nil {
-		return nil, err
+		return nil, detailedResponse, err
 	}
 
 	// Check if the response status code is 200 (success)
-	if response.StatusCode == 200 {
-		return rule, nil
+	if detailedResponse.StatusCode == 200 {
+		return rule, detailedResponse, nil
 	}
 
-	return nil, fmt.Errorf("failed to get rule: %s", response.RawResult)
+	return nil, detailedResponse, fmt.Errorf("failed to get rule: %s", detailedResponse.RawResult)
 }
 
 // GetCBRZoneByID gets a zone by its ID using the Context-based Restrictions service
@@ -41,4 +42,28 @@ func (infoSvc *CloudInfoService) GetCBRZoneByID(zoneID string) (*contextbasedres
 	}
 
 	return nil, fmt.Errorf("failed to get zone: %s", response.RawResult)
+}
+
+// SetCBREnforcementMode sets the enforcement mode of a rule using the Context-based Restrictions service
+func (infoSvc *CloudInfoService) SetCBREnforcementMode(ruleID string, mode string) error {
+	if mode != "enabled" && mode != "report" && mode != "disabled" {
+		return fmt.Errorf("invalid CBR enforcement mode: %s, valid options enabled, report, or disabled", mode)
+	}
+
+	existingRule, detailedResponse, rule_err := infoSvc.GetCBRRuleByID(ruleID)
+	if rule_err != nil {
+		return fmt.Errorf("failed to get rule: %s", rule_err)
+	}
+	// Extract the eTag from the DetailedResponse struct
+	eTag := detailedResponse.GetHeaders().Get("eTag")
+
+	existingRule.EnforcementMode = &mode
+
+	// Call the ReplaceCBRRule method to update the rule with the modified version
+	_, _, err := infoSvc.ReplaceCBRRule(existingRule, &eTag)
+	if err != nil {
+		return fmt.Errorf("failed to update rule: %s", err)
+	}
+
+	return nil
 }

--- a/cloudinfo/mock_test.go
+++ b/cloudinfo/mock_test.go
@@ -134,6 +134,10 @@ type cbrServiceMock struct {
 	err              error
 }
 
+func (mock *cbrServiceMock) ReplaceRule(options *contextbasedrestrictionsv1.ReplaceRuleOptions) (*contextbasedrestrictionsv1.Rule, *core.DetailedResponse, error) {
+	return mock.rule, mock.detailedResponse, mock.err
+}
+
 func (mock *cbrServiceMock) GetZone(options *contextbasedrestrictionsv1.GetZoneOptions) (*contextbasedrestrictionsv1.Zone, *core.DetailedResponse, error) {
 	return mock.zone, mock.detailedResponse, mock.err
 }

--- a/cloudinfo/service.go
+++ b/cloudinfo/service.go
@@ -87,7 +87,36 @@ type ibmPICloudConnectionClient interface {
 
 type cbrService interface {
 	GetRule(*contextbasedrestrictionsv1.GetRuleOptions) (*contextbasedrestrictionsv1.Rule, *core.DetailedResponse, error)
+	ReplaceRule(*contextbasedrestrictionsv1.ReplaceRuleOptions) (*contextbasedrestrictionsv1.Rule, *core.DetailedResponse, error)
 	GetZone(*contextbasedrestrictionsv1.GetZoneOptions) (*contextbasedrestrictionsv1.Zone, *core.DetailedResponse, error)
+}
+
+// ReplaceCBRRule replaces a CBR rule using the provided options.
+// updatedExistingRule is the rule to be replaced with the changes already made.
+// eTag is the eTag of the existing rule that is being replaced.
+func (infoSvc *CloudInfoService) ReplaceCBRRule(updatedExistingRule *contextbasedrestrictionsv1.Rule, eTag *string) (*contextbasedrestrictionsv1.Rule, *core.DetailedResponse, error) {
+	// Ensure that the CBR service is initialized in the CloudInfoService
+	if infoSvc.cbrService == nil {
+		return nil, nil, errors.New("CBR service is not initialized")
+	}
+
+	updatedRuleOptions := &contextbasedrestrictionsv1.ReplaceRuleOptions{
+		RuleID:          updatedExistingRule.ID,
+		Description:     updatedExistingRule.Description,
+		Contexts:        updatedExistingRule.Contexts,
+		Resources:       updatedExistingRule.Resources,
+		Operations:      updatedExistingRule.Operations,
+		EnforcementMode: updatedExistingRule.EnforcementMode,
+		IfMatch:         eTag,
+	}
+	// Call the ReplaceRuleWithContext method of the CBR service
+	rule, response, err := infoSvc.cbrService.ReplaceRule(updatedRuleOptions)
+
+	if err != nil {
+		return nil, response, err
+	}
+
+	return rule, response, nil
 }
 
 // SortedRegionsDataByPriority is an array of RegionData struct that is used as a receiver to implement the

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -54,6 +54,11 @@ type TestOptions struct {
 	// standard test variables.
 	TerraformVars map[string]interface{}
 
+	// When set during teardown this Terraform output will be used to disable CBR Rules that were created during the
+	// test to allow to destroy to complete.
+	// The last latest state of the terraform output will be used, and expects a list of CBR Rule IDs in string format.
+	CBRRuleListOutputVariable string
+
 	// This is the subdirectory of the project that contains the terraform to run for the test.
 	// This value is relative to the root directory of the project.
 	// Defaults to root directory of project if not supplied.


### PR DESCRIPTION
### Description

Adds a function for setting CBR Enforcment mode and a new Terraform option to automatically disable CBR rules in teardown before destroy.  

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
