### PR TITLE
disable logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-13T15:26:55Z",
+  "generated_at": "2023-10-16T15:36:39Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -138,7 +138,7 @@
         "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 447,
+        "line_number": 452,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -146,7 +146,7 @@
         "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 460,
+        "line_number": 465,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -201,7 +201,12 @@ func (options *TestOptions) testTearDown() {
 	// Get the output of the last terraform apply
 	// NOTE: this is done before the destroy so that the output is available for debugging
 	var outputErr error
+
+	// Turn off logging for this step so sensitive data is not logged
+	options.TerraformOptions.Logger = logger.Discard
 	options.LastTestTerraformOutputs, outputErr = terraform.OutputAllE(options.Testing, options.TerraformOptions)
+	options.TerraformOptions.Logger = logger.Default // turn log back on
+
 	if outputErr != nil {
 		logger.Log(options.Testing, "failed to get terraform output: ", outputErr)
 	}


### PR DESCRIPTION
### Description

currently terraform outputs all output to logs. This disable it

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
