### PR TITLE
fix: change schematic netrc from map to string array

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-17T12:21:41Z",
+  "generated_at": "2023-10-17T19:54:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -189,16 +189,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 534,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "testschematic/schematics.go": [
-      {
-        "hashed_secret": "d5145e4a718181e467baf4e69054e1f6ff41042d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 709,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/google/go-cmp v0.6.0
 	github.com/gruntwork-io/terratest v0.46.0
+	github.com/hashicorp/terraform-json v0.17.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.14.0
@@ -69,7 +70,6 @@ require (
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
-	github.com/hashicorp/terraform-json v0.17.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/testschematic/schematics.go
+++ b/testschematic/schematics.go
@@ -699,20 +699,22 @@ func addWorkspaceEnv(values *[]map[string]interface{}, metadata *[]schematics.En
 
 func addNetrcToWorkspaceEnv(values *[]map[string]interface{}, metadata *[]schematics.EnvironmentValuesMetadata, netrcEntries []NetrcCredential) {
 	// Create a slice to store netrc entries
-	netrcValue := []interface{}{}
+	netrcValue := [][]string{}
 
 	// Loop through provided entries and add to the slice
 	for _, netrc := range netrcEntries {
-		entry := map[string]interface{}{
-			"host":     netrc.Host,
-			"username": netrc.Username,
-			"password": netrc.Password,
+		entry := []string{
+			netrc.Host,
+			netrc.Username,
+			netrc.Password,
 		}
 		netrcValue = append(netrcValue, entry)
 	}
 
+	// turn entire array into string
+	netrcValueStr, _ := common.ConvertArrayToJsonString(netrcValue)
 	// Add the slice of netrc entries to env with "__netrc__" as the key
-	*values = append(*values, map[string]interface{}{"__netrc__": netrcValue})
+	*values = append(*values, map[string]interface{}{"__netrc__": netrcValueStr})
 
 	// Add a metadata entry for the sensitive value
 	*metadata = append(*metadata, schematics.EnvironmentValuesMetadata{


### PR DESCRIPTION
### Description

Configuration for the `__netrc__` environment variable for schematics has changed from a json map to a simple json string containing an array of strings, in order of host/user/password.

Changed the implementation of `testschematic.addNetrcToWorkspaceEnv()` so that the appropriate format for netrc is sent to API.

Format reference here: https://cloud.ibm.com/docs/schematics?topic=schematics-download-modules-pvt-git

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Changed the implementation of `testschematic.addNetrcToWorkspaceEnv()` so that the format of the `__netrc__` value in the schematics template environment variable is in the correct format.

The old format was a map of keys and strings, the new format is a simple array of strings with no keys.

Format reference here: https://cloud.ibm.com/docs/schematics?topic=schematics-download-modules-pvt-git

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
