### PR TITLE
feat: unskip tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-11-14T11:00:26Z",
+  "generated_at": "2023-11-24T15:40:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -180,7 +180,7 @@
         "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 537,
+        "line_number": 538,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 550,
+        "line_number": 551,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -3,12 +3,13 @@ package testhelper
 import (
 	"encoding/json"
 	"fmt"
-	tfjson "github.com/hashicorp/terraform-json"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
 	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
 
@@ -35,6 +36,9 @@ func skipUpgradeTest(branch string) bool {
 	if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") {
 		doNotRunUpgradeTest = true
 	}
+	if strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
+		doNotRunUpgradeTest = false
+	}
 	if !doNotRunUpgradeTest {
 		// NOTE: using the "origin" of the default branch as the start point, which will exist in a fresh
 		// clone even if the default branch has not been checked out or pulled.
@@ -43,6 +47,9 @@ func skipUpgradeTest(branch string) bool {
 
 		if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") {
 			doNotRunUpgradeTest = true
+		}
+		if strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
+			doNotRunUpgradeTest = false
 		}
 	}
 	return doNotRunUpgradeTest

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -33,7 +33,7 @@ func skipUpgradeTest(branch string) bool {
 
 	// Skip upgrade Test if BREAKING CHANGE OR SKIP UPGRADE TEST string found in commit messages
 	doNotRunUpgradeTest := false
-	if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
+	if (strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST")) && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
 		doNotRunUpgradeTest = true
 	}
 	if !doNotRunUpgradeTest {
@@ -42,7 +42,7 @@ func skipUpgradeTest(branch string) bool {
 		cmd = exec.Command("/bin/sh", "-c", "git log origin/main..", branch)
 		out, _ = cmd.CombinedOutput()
 
-		if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
+		if (strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST")) && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
 			doNotRunUpgradeTest = true
 		}
 	}

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -33,11 +33,8 @@ func skipUpgradeTest(branch string) bool {
 
 	// Skip upgrade Test if BREAKING CHANGE OR SKIP UPGRADE TEST string found in commit messages
 	doNotRunUpgradeTest := false
-	if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") {
+	if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
 		doNotRunUpgradeTest = true
-	}
-	if strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
-		doNotRunUpgradeTest = false
 	}
 	if !doNotRunUpgradeTest {
 		// NOTE: using the "origin" of the default branch as the start point, which will exist in a fresh
@@ -45,11 +42,8 @@ func skipUpgradeTest(branch string) bool {
 		cmd = exec.Command("/bin/sh", "-c", "git log origin/main..", branch)
 		out, _ = cmd.CombinedOutput()
 
-		if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") {
+		if strings.Contains(string(out), "BREAKING CHANGE") || strings.Contains(string(out), "SKIP UPGRADE TEST") && !strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
 			doNotRunUpgradeTest = true
-		}
-		if strings.Contains(string(out), "UNSKIP UPGRADE TEST") {
-			doNotRunUpgradeTest = false
 		}
 	}
 	return doNotRunUpgradeTest


### PR DESCRIPTION
### Description

Add option to unskip unit tests. This will be an option after skipping unit tests, but you cannot disable upgrade tests once again after undoing a skip. Maybe we want to parse logs and json and look at commit message dates etc to do this logic https://maori.geek.nz/git-log-as-json-in-go-59d8e1d09fb5. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
