### PR TITLE
Opentofu support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-02-27T15:29:36Z",
+  "generated_at": "2024-03-19T17:32:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -180,7 +180,7 @@
         "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 642,
+        "line_number": 643,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -188,7 +188,7 @@
         "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 655,
+        "line_number": 656,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,38 @@ if assert.NoErrorf(t, outputErr, "Some outputs not found or nil.") {
     assert.Equal(t, outputs["output2"].(string), "output 2")
 }
 ```
+---
+
+### OpenTofu
+
+Enable open Tofu with the TerraformOptions and OpenTofu on the systems path will be used for the test.
+```go
+func TestRunBasicTofu(t *testing.T) {
+	t.Parallel()
+
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+        Testing:            t,                      // the test object for unit test
+        EnableOpenTofu:     true,                   // enable open Tofu
+        TerraformDir:       "examples/basic",       // location of example to test
+        Prefix:             "my-test",              // will have 6 char random string appended
+        BestRegionYAMLPath: "location/of/yaml.yml", // YAML file to configure dynamic region selection
+        // Region: "us-south", // if you set Region, dynamic selection will be skipped
+    })
+
+    options.TerraformVars = map[string]interface{}{
+        "variable_1":   "foo",
+        "resource_prefix": options.Prefix,
+        "ibm_region": options.Region,
+    }
+
+    // idempotent test
+    output, err := options.RunTestConsistency()
+    assert.Nil(t, err, "This should not have errored")
+    assert.NotNil(t, output, "Expected some output")
+}
+
+```
+
 ___
 
 ### Run in IBM Cloud Schematics

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ if assert.NoErrorf(t, outputErr, "Some outputs not found or nil.") {
 
 ### OpenTofu
 
-Enable open Tofu with the TerraformOptions and OpenTofu on the systems path will be used for the test.
+Enable OpenTofu with the TestOptions, then OpenTofu on the systems path will be used for the test.
 ```go
 func TestRunBasicTofu(t *testing.T) {
 	t.Parallel()

--- a/README.md
+++ b/README.md
@@ -134,7 +134,33 @@ func TestRunBasicTofu(t *testing.T) {
 }
 
 ```
+The `TerraformBinary` can also be set directly if Terrform/OpenTofu is not in the system path. If this is set the `EnableOpenTofu` option will be ignored.
+```go
+func TestRunBasicTerraformBinary(t *testing.T) {
+	t.Parallel()
 
+	options := testhelper.TestOptionsDefault(&testhelper.TestOptions{
+        Testing:            t,                      // the test object for unit test
+        TerraformBinary:    "/custom/path/tofu",    // set the path to the Terraform binary
+        TerraformDir:       "examples/basic",       // location of example to test
+        Prefix:             "my-test",              // will have 6 char random string appended
+        BestRegionYAMLPath: "location/of/yaml.yml", // YAML file to configure dynamic region selection
+        // Region: "us-south", // if you set Region, dynamic selection will be skipped
+    })
+
+    options.TerraformVars = map[string]interface{}{
+        "variable_1":   "foo",
+        "resource_prefix": options.Prefix,
+        "ibm_region": options.Region,
+    }
+
+    // idempotent test
+    output, err := options.RunTestConsistency()
+    assert.Nil(t, err, "This should not have errored")
+    assert.NotNil(t, output, "Expected some output")
+}
+
+```
 ___
 
 ### Run in IBM Cloud Schematics

--- a/testhelper/terraform.go
+++ b/testhelper/terraform.go
@@ -16,11 +16,19 @@ import (
 
 // RemoveFromStateFile Attempts to remove resource from state file
 func RemoveFromStateFile(stateFile string, resourceAddress string) (string, error) {
+	return RemoveFromStateFileV2(stateFile, resourceAddress, "terraform")
+}
+
+// RemoveFromStateFileV2 Attempts to remove resource from state file
+// stateFile: The path to the state file
+// resourceAddress: The address of the resource to remove
+// tfBinary: The path to the terraform binary
+func RemoveFromStateFileV2(stateFile string, resourceAddress string, tfBinary string) (string, error) {
 	var errorMsg string
 	if files.PathContainsTerraformState(stateFile) {
 		stateDir := filepath.Dir(stateFile)
 		log.Printf("Removing %s from Statefile %s\n", resourceAddress, stateFile)
-		command := fmt.Sprintf("terraform state rm %s", resourceAddress)
+		command := fmt.Sprintf("%s state rm %s", tfBinary, resourceAddress)
 		log.Printf("Executing: %s", command)
 		cmd := exec.Command("/bin/sh", "-c", command)
 		cmd.Dir = stateDir

--- a/testhelper/terraform.go
+++ b/testhelper/terraform.go
@@ -25,6 +25,9 @@ func RemoveFromStateFile(stateFile string, resourceAddress string) (string, erro
 // tfBinary: The path to the terraform binary
 func RemoveFromStateFileV2(stateFile string, resourceAddress string, tfBinary string) (string, error) {
 	var errorMsg string
+	if tfBinary == "" {
+		tfBinary = "terraform"
+	}
 	if files.PathContainsTerraformState(stateFile) {
 		stateDir := filepath.Dir(stateFile)
 		log.Printf("Removing %s from Statefile %s\n", resourceAddress, stateFile)

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -224,9 +224,6 @@ func TestOptionsDefault(originalOptions *TestOptions) *TestOptions {
 	newOptions.UseTerraformWorkspace = false
 
 	// if originalOptions has TerraformBinary set, use that value. Otherwise, use OpenTofu
-	if newOptions.TerraformOptions == nil {
-		newOptions.TerraformOptions = &terraform.Options{}
-	}
 	if newOptions.TerraformBinary == "" {
 		if newOptions.EnableOpenTofu {
 			_, err := exec.LookPath("tofu")

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -75,7 +75,8 @@ type TestOptions struct {
 	// Use OpenTofu binary on the system path. This is used to enable the OpenTofu binary to be used for testing.
 	// If OpenTofu is not installed, the test will fail.
 	// If TerraformOptions is passed with the value for TerraformBinary set, this value will be ignored.
-	EnableOpenTofu  bool
+	EnableOpenTofu bool
+	// Use this to specify the path to the Terraform binary to use for testing. This is exclusive with EnableOpenTofu.
 	TerraformBinary string
 
 	// Use these options to have terratest execute using a terraform "workspace".

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -234,6 +234,8 @@ func TestOptionsDefault(originalOptions *TestOptions) *TestOptions {
 			if err == nil {
 				newOptions.TerraformBinary = "tofu"
 			}
+		} else {
+			newOptions.TerraformBinary = "terraform"
 		}
 	}
 

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -226,18 +226,14 @@ func TestOptionsDefault(originalOptions *TestOptions) *TestOptions {
 	if newOptions.TerraformOptions == nil {
 		newOptions.TerraformOptions = &terraform.Options{}
 	}
-	if newOptions.TerraformOptions.TerraformBinary == "" {
-		// check tofu exists on system
+	if newOptions.TerraformBinary == "" {
 		if newOptions.EnableOpenTofu {
 			_, err := exec.LookPath("tofu")
 			require.NoError(newOptions.Testing, err, "tofu binary not found on system, please install tofu or set TerraformBinary in TestOptions.")
 			if err == nil {
-				newOptions.TerraformOptions.TerraformBinary = "tofu"
 				newOptions.TerraformBinary = "tofu"
 			}
 		}
-	} else {
-		newOptions.TerraformBinary = newOptions.TerraformOptions.TerraformBinary
 	}
 
 	if newOptions.Region == "" {

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -328,7 +328,7 @@ func (options *TestOptions) testTearDown() {
 			for _, address := range options.ImplicitDestroy {
 				// TODO: is this the correct path to the state file? and/or does it need to be updated upstream to a relative path(temp dir)?
 				statefile := fmt.Sprintf("%s/terraform.tfstate", options.WorkspacePath)
-				out, err := RemoveFromStateFile(statefile, address)
+				out, err := RemoveFromStateFileV2(statefile, address, options.TerraformBinary)
 				if options.ImplicitRequired && err != nil {
 					logger.Log(options.Testing, out)
 					assert.Nil(options.Testing, err, "Could not remove from state file")

--- a/testhelper/tests.go
+++ b/testhelper/tests.go
@@ -229,8 +229,9 @@ func (options *TestOptions) testSetup() {
 			// retryable errors in terraform testing.
 			options.TerraformOptions = terraform.WithDefaultRetryableErrors(options.Testing, &terraform.Options{
 				// Set the path to the Terraform code that will be tested.
-				TerraformDir: options.TerraformDir,
-				Vars:         options.TerraformVars,
+				TerraformDir:    options.TerraformDir,
+				TerraformBinary: options.TerraformBinary,
+				Vars:            options.TerraformVars,
 				// Set Upgrade to true to ensure the latest version of providers and modules are used by terratest.
 				// This is the same as setting the -upgrade=true flag with terraform.
 				Upgrade: true,

--- a/testhelper/tests_test.go
+++ b/testhelper/tests_test.go
@@ -42,6 +42,27 @@ func TestRunTest(t *testing.T) {
 
 }
 
+func TestRunTestTofu(t *testing.T) {
+	t.Parallel()
+	os.Setenv("TF_VAR_ibmcloud_api_key", "12345")
+	options := TestOptionsDefaultWithVars(&TestOptions{
+		Testing:        t,
+		TerraformDir:   sample1,
+		Prefix:         "testRun",
+		ResourceGroup:  "test-rg",
+		Region:         "us-south",
+		TerraformVars:  terraformVars,
+		EnableOpenTofu: true,
+	})
+	output, err := options.RunTest()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
+	assert.Contains(t, output, "OpenTofu used")
+	assert.NotNil(t, options.LastTestTerraformOutputs, "Expected some Terraform outputs")
+	_, outErr := ValidateTerraformOutputs(options.LastTestTerraformOutputs, sample1ExpectedOutputs...)
+	assert.Nil(t, outErr, outErr)
+
+}
 func TestRunTestContainsScript(t *testing.T) {
 	t.Parallel()
 	os.Setenv("TF_VAR_ibmcloud_api_key", "12345")


### PR DESCRIPTION
### Description

Add support to enable OpenTofu usage in tests. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- add support to enable OpenTofu in testOptions

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
