### PR TITLE
feat: simplify testprojects TearDown logic

### DIFF
--- a/testprojects/tests_test.go
+++ b/testprojects/tests_test.go
@@ -1,1 +1,123 @@
 package testprojects
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCorrectResourceTeardownFlag(t *testing.T) {
+
+	// Test success and no skips
+	t.Run("SuccessNoSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing: new(testing.T),
+		}
+		assert.Equal(t, true, o.executeResourceTearDown())
+	})
+
+	t.Run("SuccessWithSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      true,
+			SkipProjectDelete: false,
+		}
+		assert.Equal(t, false, o.executeResourceTearDown())
+	})
+
+	t.Run("FailNoSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: false,
+		}
+		o.Testing.Fail()
+		assert.Equal(t, true, o.executeResourceTearDown())
+	})
+
+	t.Run("FailWithSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      true,
+			SkipProjectDelete: false,
+		}
+		o.Testing.Fail()
+		assert.Equal(t, false, o.executeResourceTearDown())
+	})
+
+	t.Run("FailNoSkipWithIgnore", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: false,
+		}
+		os.Setenv("DO_NOT_DESTROY_ON_FAILURE", "true")
+		o.Testing.Fail()
+		assert.Equal(t, false, o.executeResourceTearDown())
+		os.Unsetenv("DO_NOT_DESTROY_ON_FAILURE")
+	})
+
+	t.Run("FailNoSkipWithIgnoreOff", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: false,
+		}
+		os.Setenv("DO_NOT_DESTROY_ON_FAILURE", "false")
+		o.Testing.Fail()
+		assert.Equal(t, true, o.executeResourceTearDown())
+		os.Unsetenv("DO_NOT_DESTROY_ON_FAILURE")
+	})
+
+	t.Run("FailWithSkipWithIgnore", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: false,
+		}
+		os.Setenv("DO_NOT_DESTROY_ON_FAILURE", "true")
+		o.Testing.Fail()
+		assert.Equal(t, false, o.executeResourceTearDown())
+		os.Unsetenv("DO_NOT_DESTROY_ON_FAILURE")
+	})
+}
+
+func TestCorrectProjectTeardownFlag(t *testing.T) {
+
+	t.Run("SuccessNoSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing: new(testing.T),
+		}
+		assert.Equal(t, true, o.executeProjectTearDown())
+	})
+
+	t.Run("SuccessWithSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: true,
+		}
+		assert.Equal(t, false, o.executeProjectTearDown())
+	})
+
+	t.Run("FailNoSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      false,
+			SkipProjectDelete: false,
+		}
+		o.Testing.Fail()
+		assert.Equal(t, false, o.executeProjectTearDown())
+	})
+
+	t.Run("FailWithSkip", func(t *testing.T) {
+		o := TestProjectsOptions{
+			Testing:           new(testing.T),
+			SkipUndeploy:      true,
+			SkipProjectDelete: false,
+		}
+		o.Testing.Fail()
+		assert.Equal(t, false, o.executeProjectTearDown())
+	})
+}


### PR DESCRIPTION
### Description

Simplified the TearDown logic in the testprojects package, more specifically around when TearDown is skipped for both resources and the parent stack project.

Added two new private functions in testprojects to wrap the logic around when both resource and project undeployment should take place to easier manage the logic in the future. Also added some new unit tests for these two functions to test all the various permutations and outcomes.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Simplified the logic around when resources or projects should get deleted during TestTearDown in the testprojects package, also added unit tests to verify all permutations.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
