### PR TITLE
feat: allow deep folders in stack config path

### DIFF
--- a/testprojects/test_options.go
+++ b/testprojects/test_options.go
@@ -2,14 +2,15 @@ package testprojects
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	project "github.com/IBM/project-go-sdk/projectv1"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
-	"strings"
-	"testing"
 )
 
 const defaultRegion = "us-south"
@@ -107,16 +108,12 @@ func TestProjectOptionsDefault(originalOptions *TestProjectsOptions) *TestProjec
 	if newOptions.ResourceGroup == "" {
 		newOptions.ResourceGroup = "Default"
 	}
-	// TODO: default stack configuration path and catalog path to repo root stack_definition.json and ibm_catalog.json
-	repoRoot, repoErr := common.GitRootPath(".")
-	if repoErr != nil {
-		repoRoot = "."
-	}
+
 	if newOptions.StackConfigurationPath == "" {
-		newOptions.StackConfigurationPath = fmt.Sprintf("%s/stack_definition.json", repoRoot)
+		newOptions.StackConfigurationPath = "stack_definition.json"
 	}
 	if newOptions.StackCatalogJsonPath == "" {
-		newOptions.StackCatalogJsonPath = fmt.Sprintf("%s/ibm_catalog.json", repoRoot)
+		newOptions.StackCatalogJsonPath = "ibm_catalog.json"
 	}
 	if newOptions.ValidationTimeoutMinutes == 0 {
 		newOptions.ValidationTimeoutMinutes = 60


### PR DESCRIPTION
### Description

Changed logic in `testprojects` package to allow `TestProjectsOptions.StackConfigurationPath` and other path properties to support nested folders inside of the project (previously only supported config files in root of project).

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

`TestProjectsOptions.StackConfigurationPath`, and the other path variables in same structure, now support nested folder structure within the repository to locate configuration files.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
