### PR TITLE
fix: schematics upgrade refactor to tar file only

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-01-24T16:21:04Z",
+  "generated_at": "2025-01-29T15:25:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -164,7 +164,23 @@
         "hashed_secret": "bff8f8143a073833d713e3c1821fe97661bc3cef",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 318,
+        "line_number": 320,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 465,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b994b23302ebc7b46888b0f5c623bfc2bcfa2e3f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 478,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -207,24 +223,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 153,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
-    "testhelper/tests.go": [
-      {
-        "hashed_secret": "b4e929aa58c928e3e44d12e6f873f39cd8207a25",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 487,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "16282376ddaaaf2bf60be9041a7504280f3f338b",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 500,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -164,6 +164,9 @@ type TestSchematicOptions struct {
 	// NOTE: this is not an option field that is meant to be set from a unit test, it is informational only
 	IsUpgradeTest      bool
 	UpgradeTestSkipped bool // Informs the calling test that conditions were met to skip the upgrade test
+
+	// Set to true if you wish for an Upgrade test to do a final `terraform apply` after the consistency check on the new (not base) branch.
+	CheckApplyResultForUpgrade bool
 }
 
 type TestSchematicTerraformVar struct {

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -159,10 +159,11 @@ type TestSchematicOptions struct {
 	// Set this value to `true` to have all schematics job logs (plan/apply/destroy) printed to the test log.
 	PrintAllSchematicsLogs bool
 
-	// This property will be set to true by the test when an upgrade test was performed.
+	// These properties will be set to true by the test when an upgrade test was performed.
 	// You can then inspect this value after the test run, if needed, to make further code decisions.
 	// NOTE: this is not an option field that is meant to be set from a unit test, it is informational only
-	IsUpgradeTest bool
+	IsUpgradeTest      bool
+	UpgradeTestSkipped bool // Informs the calling test that conditions were met to skip the upgrade test
 }
 
 type TestSchematicTerraformVar struct {

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -80,12 +80,6 @@ type TestSchematicOptions struct {
 	// to that value.
 	TemplateFolder string
 
-	// The Git auth token used by schematics to clone initial template source of project.
-	// If TAR upload option is not used, the default will be to use the Git URL of the test branch for initial schematics workload setup.
-	// If the test repo is private or protected, set this value to a Git token that is authorized to read/clone the repository.
-	// NOTE: you may also need to set the same token in a `NetrcSettings` as well for this scenario.
-	TemplateGitToken string
-
 	// Optional list of tags that will be applied to the Schematics Workspace instance
 	Tags []string
 

--- a/testschematic/tests.go
+++ b/testschematic/tests.go
@@ -85,6 +85,7 @@ func executeSchematicTest(options *TestSchematicOptions, performUpgradeTest bool
 	if performUpgradeTest {
 		if common.SkipUpgradeTest(options.Testing, svc.BaseTerraformRepo, svc.BaseTerraformRepoBranch, svc.TestTerraformRepoBranch) {
 			options.Testing.Log("Detected the string \"BREAKING CHANGE\" or \"SKIP UPGRADE TEST\" used in commit message, skipping upgrade Test.")
+			svc.TestOptions.UpgradeTestSkipped = true
 			return nil
 		}
 	}

--- a/testschematic/tests.go
+++ b/testschematic/tests.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,11 @@ func (options *TestSchematicOptions) RunSchematicTest() error {
 // 6. delete the test workspace
 func (options *TestSchematicOptions) RunSchematicUpgradeTest() error {
 	options.IsUpgradeTest = true
+	// Skip upgrade Test in continuous testing pipeline which runs in short mode
+	if testing.Short() {
+		options.UpgradeTestSkipped = true
+		options.Testing.Skip("Skipping upgrade Test in short mode.")
+	}
 	return executeSchematicTest(options, true)
 }
 


### PR DESCRIPTION
### Description

This fix will revert the use of HTTPS configuration of schematics workspaces, and allow only TAR file upload to schematics for regular and upgrade tests. This change is to avoid a situation where schematics cannot properly determine or use the git endpoints in the GHA or Tekton pipelines due to the nature of the cloned repos (with detached HEAD).

This new change will perform schematics upgrade tests just like the regular terratest logic works.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
