### PR TITLE
fix: schematics convert inputs to json

### DIFF
--- a/common/general.go
+++ b/common/general.go
@@ -10,15 +10,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/openpgp"
-	"golang.org/x/crypto/openpgp/packet"
-	"golang.org/x/crypto/ssh"
-	"gopkg.in/yaml.v3"
 	"io"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/packet"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/require"
 )
@@ -126,12 +127,12 @@ func ConditionalAdd(amap map[string]interface{}, key string, value string, compa
 	}
 }
 
-// ConvertArrayToJsonString is a helper function that will take an array of Golang data types, and return a string
-// of the array formatted as a JSON array.
-// Helpful to convert Golang arrays into a format that Terraform can consume.
-func ConvertArrayToJsonString(arr interface{}) (string, error) {
+// ConvertValueToJsonString is a helper function that will take an interface of any Golang data types, and return a string
+// of the array formatted as a JSON value.
+// Helpful to convert Golang composite types into a format that Terraform can consume.
+func ConvertValueToJsonString(val interface{}) (string, error) {
 	// first marshal array into json compatible
-	json, jsonErr := json.Marshal(arr)
+	json, jsonErr := json.Marshal(val)
 	if jsonErr != nil {
 		return "", jsonErr
 	}
@@ -145,10 +146,32 @@ func ConvertArrayToJsonString(arr interface{}) (string, error) {
 // IsArray is a simple helper function that will determine if a given Golang value is a slice or array.
 func IsArray(v interface{}) bool {
 
-	theType := reflect.TypeOf(v).Kind()
+	// avoid panic, check for nil first
+	if v != nil {
+		theType := reflect.TypeOf(v).Kind()
 
-	if (theType == reflect.Slice) || (theType == reflect.Array) {
-		return true
+		if (theType == reflect.Slice) || (theType == reflect.Array) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsCompositeType is a simple helper function that will determine if a given Golang value is a non-primitive (composite) type.
+func IsCompositeType(v interface{}) bool {
+
+	// avoid panic, check for nil first
+	if v != nil {
+		theType := reflect.TypeOf(v).Kind()
+
+		if (theType == reflect.Slice) ||
+			(theType == reflect.Array) ||
+			(theType == reflect.Map) ||
+			(theType == reflect.Struct) ||
+			(theType == reflect.Interface) {
+			return true
+		}
 	}
 
 	return false

--- a/common/general_test.go
+++ b/common/general_test.go
@@ -76,14 +76,14 @@ func TestConvertArrayJson(t *testing.T) {
 			99,
 			"bye",
 		}
-		goodStr, goodErr := ConvertArrayToJsonString(goodArr)
+		goodStr, goodErr := ConvertValueToJsonString(goodArr)
 		if assert.NoError(t, goodErr, "error converting array") {
 			assert.NotEmpty(t, goodStr)
 		}
 	})
 
 	t.Run("NilValue", func(t *testing.T) {
-		nullVal, nullErr := ConvertArrayToJsonString(nil)
+		nullVal, nullErr := ConvertValueToJsonString(nil)
 		if assert.NoError(t, nullErr) {
 			assert.Equal(t, "null", nullVal)
 		}
@@ -91,7 +91,7 @@ func TestConvertArrayJson(t *testing.T) {
 
 	t.Run("NullPointer", func(t *testing.T) {
 		var intPtr *int
-		ptrVal, ptrErr := ConvertArrayToJsonString(intPtr)
+		ptrVal, ptrErr := ConvertValueToJsonString(intPtr)
 		if assert.NoError(t, ptrErr) {
 			assert.Equal(t, "null", ptrVal)
 		}
@@ -138,6 +138,55 @@ func TestIsArray(t *testing.T) {
 		obj := &TestObject{"hello", 99}
 		sis := IsArray(*obj)
 		assert.False(t, sis)
+	})
+}
+
+func TestIsComposite(t *testing.T) {
+
+	t.Run("IsSlice", func(t *testing.T) {
+		slice := []int{1, 2, 3}
+		isSlice := IsCompositeType(slice)
+		assert.True(t, isSlice)
+	})
+
+	t.Run("IsArray", func(t *testing.T) {
+		arr := [3]int{1, 2, 3}
+		isArr := IsCompositeType(arr)
+		assert.True(t, isArr)
+	})
+
+	t.Run("TryString", func(t *testing.T) {
+		val := "hello"
+		is := IsCompositeType(val)
+		assert.False(t, is)
+	})
+
+	t.Run("TryBool", func(t *testing.T) {
+		bval := true
+		bis := IsCompositeType(bval)
+		assert.False(t, bis)
+	})
+
+	t.Run("TryNumber", func(t *testing.T) {
+		nval := 99.99
+		nis := IsCompositeType(nval)
+		assert.False(t, nis)
+	})
+
+	t.Run("TryStruct", func(t *testing.T) {
+		type TestObject struct {
+			prop1 string
+			prop2 int
+		}
+		obj := &TestObject{"hello", 99}
+		sis := IsCompositeType(*obj)
+		assert.True(t, sis)
+	})
+
+	t.Run("TryMap", func(t *testing.T) {
+		mapVal := map[string]string{"one": "1", "two": "2"}
+		sis := IsCompositeType(mapVal)
+		assert.True(t, sis)
 	})
 }
 

--- a/testschematic/schematics.go
+++ b/testschematic/schematics.go
@@ -270,9 +270,9 @@ func (svc *SchematicsTestService) UpdateTestTemplateVars(vars []TestSchematicTer
 	var strErr error
 	variables := []schematics.WorkspaceVariableRequest{}
 	for _, tfVar := range vars {
-		// if tfVal is an array, convert to json array string
-		if common.IsArray(tfVar.Value) {
-			strVal, strErr = common.ConvertArrayToJsonString(tfVar.Value)
+		// if tfVal is an array or map, convert to json string
+		if common.IsCompositeType(tfVar.Value) {
+			strVal, strErr = common.ConvertValueToJsonString(tfVar.Value)
 			if strErr != nil {
 				return strErr
 			}
@@ -815,7 +815,7 @@ func addNetrcToWorkspaceEnv(values *[]map[string]interface{}, metadata *[]schema
 	}
 
 	// turn entire array into string
-	netrcValueStr, _ := common.ConvertArrayToJsonString(netrcValue)
+	netrcValueStr, _ := common.ConvertValueToJsonString(netrcValue)
 	// Add the slice of netrc entries to env with "__netrc__" as the key
 	*values = append(*values, map[string]interface{}{"__netrc__": netrcValueStr})
 

--- a/testschematic/tests.go
+++ b/testschematic/tests.go
@@ -388,11 +388,13 @@ func testTearDown(svc *SchematicsTestService, options *TestSchematicOptions) {
 	}()
 
 	// retrieve and store the last set of outputs right before destroy
-	outputs, outputsErr := svc.GetLatestWorkspaceOutputs()
-	if outputsErr != nil {
-		options.Testing.Logf("[SCHEMATICS] There was an error retrieving output values: %s", outputsErr)
-	} else {
-		options.LastTestTerraformOutputs = outputs
+	if svc.TerraformResourcesCreated {
+		outputs, outputsErr := svc.GetLatestWorkspaceOutputs()
+		if outputsErr != nil {
+			options.Testing.Logf("[SCHEMATICS] There was an error retrieving output values: %s", outputsErr)
+		} else {
+			options.LastTestTerraformOutputs = outputs
+		}
 	}
 
 	// only perform if skip is not set


### PR DESCRIPTION
### Description

Small fix for schematics tests, that will now convert more composite input value types using a Json Marshal, so that their format when sent to schematics workspace is in proper json format instead of golang. The list of composite golang types that are converted are now:
- Array
- Slice
- Map (new)
- Struct (new)
- Interface (new)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
