### PR TITLE
fix: update repo url resolution for addons

### DIFF
--- a/testaddons/tests.go
+++ b/testaddons/tests.go
@@ -422,6 +422,22 @@ func (options *TestAddonOptions) testSetup() error {
 		return fmt.Errorf("error getting current branch and repo: %w", repoErr)
 	}
 	options.currentBranch = &branch
+
+	// Convert repository URL to HTTPS format for catalog import
+	if strings.HasPrefix(repo, "git@") {
+		// Convert SSH format: git@github.com:username/repo.git → https://github.com/username/repo
+		repo = strings.Replace(repo, ":", "/", 1)
+		repo = strings.Replace(repo, "git@", "https://", 1)
+		repo = strings.TrimSuffix(repo, ".git")
+	} else if strings.HasPrefix(repo, "git://") {
+		// Convert Git protocol: git://github.com/username/repo.git → https://github.com/username/repo
+		repo = strings.Replace(repo, "git://", "https://", 1)
+		repo = strings.TrimSuffix(repo, ".git")
+	} else if strings.HasPrefix(repo, "https://") {
+		// HTTPS format - just trim .git suffix if present
+		repo = strings.TrimSuffix(repo, ".git")
+	}
+
 	options.currentBranchUrl = Core.StringPtr(fmt.Sprintf("%s/tree/%s", repo, branch))
 	options.Logger.ShortInfo(fmt.Sprintf("Current branch: %s", branch))
 	options.Logger.ShortInfo(fmt.Sprintf("Current repo: %s", repo))


### PR DESCRIPTION
### Description

If a repo was cloned with ssh the url was not correctly resolved making catalog import fail. 

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
