### PR TITLE
feat: control random hash length for prefix

### DIFF
--- a/common/random.go
+++ b/common/random.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"bytes"
+	"math/rand"
+	"time"
+)
+
+const base36chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+// UniqueId returns a unique (ish) id we can attach to prefix variable passed in terraform configuration
+// length of the random string to be appended can be controller by length argument passed to the function
+func UniqueId(length ...int) string {
+
+	// Set default length to 3 characters
+	idLength := 3
+
+	// Override default if valid length parameter provided
+	if len(length) > 0 && length[0] > 0 {
+		idLength = length[0]
+	}
+	var out bytes.Buffer
+
+	generator := newRand()
+	for i := 0; i < idLength; i++ {
+		out.WriteByte(base36chars[generator.Intn(len(base36chars))])
+	}
+
+	return out.String()
+}
+
+// newRand creates a new random number generator, seeding it with the current system time.
+func newRand() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}

--- a/common/random.go
+++ b/common/random.go
@@ -9,7 +9,7 @@ import (
 const base36chars = "0123456789abcdefghijklmnopqrstuvwxyz"
 
 // UniqueId returns a unique (ish) id we can attach to prefix variable passed in terraform configuration
-// length of the random string to be appended can be controller by length argument passed to the function
+// length of the random string to be appended can be controlled by length argument passed to the function
 func UniqueId(length ...int) string {
 
 	// Set default length to 3 characters

--- a/testaddons/test_options.go
+++ b/testaddons/test_options.go
@@ -2,14 +2,12 @@ package testaddons
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/catalogmanagementv1"
 
 	project "github.com/IBM/project-go-sdk/projectv1"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
@@ -128,7 +126,7 @@ func TestAddonsOptionsDefault(originalOptions *TestAddonOptions) *TestAddonOptio
 	newOptions, err := originalOptions.Clone()
 	require.NoError(originalOptions.Testing, err)
 
-	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, strings.ToLower(random.UniqueId()))
+	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, common.UniqueId())
 	newOptions.AddonConfig.Prefix = newOptions.Prefix
 
 	// Verify required environment variables are set - better to do this now rather than retry and fail with every attempt

--- a/testhelper/test_options.go
+++ b/testhelper/test_options.go
@@ -3,10 +3,8 @@ package testhelper
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
@@ -262,7 +260,7 @@ func TestOptionsDefault(originalOptions *TestOptions) *TestOptions {
 	newOptions, err := originalOptions.Clone()
 	require.NoError(originalOptions.Testing, err)
 
-	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, strings.ToLower(random.UniqueId()))
+	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, common.UniqueId())
 
 	if newOptions.DefaultRegion == "" {
 		newOptions.DefaultRegion = defaultRegion

--- a/testprojects/test_options.go
+++ b/testprojects/test_options.go
@@ -3,13 +3,11 @@ package testprojects
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 
 	project "github.com/IBM/project-go-sdk/projectv1"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
@@ -141,7 +139,7 @@ func TestProjectOptionsDefault(originalOptions *TestProjectsOptions) *TestProjec
 	newOptions, err := originalOptions.Clone()
 	require.NoError(originalOptions.Testing, err)
 
-	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, strings.ToLower(random.UniqueId()))
+	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, common.UniqueId())
 
 	// Verify required environment variables are set - better to do this now rather than retry and fail with every attempt
 	checkVariables := []string{ibmcloudApiKeyVar}

--- a/testschematic/test_options.go
+++ b/testschematic/test_options.go
@@ -3,10 +3,8 @@ package testschematic
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
@@ -230,7 +228,7 @@ func TestSchematicOptionsDefault(originalOptions *TestSchematicOptions) *TestSch
 	newOptions, err := originalOptions.Clone()
 	require.NoError(originalOptions.Testing, err)
 
-	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, strings.ToLower(random.UniqueId()))
+	newOptions.Prefix = fmt.Sprintf("%s-%s", newOptions.Prefix, common.UniqueId())
 
 	if newOptions.DefaultRegion == "" {
 		newOptions.DefaultRegion = defaultRegion


### PR DESCRIPTION
### Description
control random hash length for prefix. Default length is 3 but can be controlled by passing an argument to UniqueId() function in common package.
<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
