### PR TITLE
Fix dep bug

### DIFF
--- a/cloudinfo/catalog.go
+++ b/cloudinfo/catalog.go
@@ -756,8 +756,8 @@ func buildHierarchicalDeploymentList(mainAddon *AddonConfig) []AddonConfig {
 
 	// Recursively process dependencies in hierarchy order
 	// This ensures topmost instances take precedence over deeper occurrences
-	var processDependencies func(addon *AddonConfig, depth int)
-	processDependencies = func(addon *AddonConfig, depth int) {
+	var processDependencies func(addon *AddonConfig)
+	processDependencies = func(addon *AddonConfig) {
 		for _, dep := range addon.Dependencies {
 			offeringKey := getOfferingKey(&dep)
 
@@ -774,13 +774,13 @@ func buildHierarchicalDeploymentList(mainAddon *AddonConfig) []AddonConfig {
 				processedOfferings[offeringKey] = true
 
 				// Recursively process this dependency's dependencies
-				processDependencies(&dep, depth+1)
+				processDependencies(&dep)
 			}
 		}
 	}
 
 	// Start processing from the main addon's dependencies
-	processDependencies(mainAddon, 0)
+	processDependencies(mainAddon)
 
 	return deploymentList
 }

--- a/docs/projects/addons/troubleshooting.md
+++ b/docs/projects/addons/troubleshooting.md
@@ -549,3 +549,30 @@ func TestMinimalReproduction(t *testing.T) {
 - IBM Cloud documentation
 - Developer forums and communities
 - IBM Cloud support channels
+
+#### Member Configuration Deployment Reference Warning
+
+**Warning message:**
+
+```text
+⚠   ref://project.example/configs/member-config/inputs/resource_group_name - Warning: unresolved
+      Message: The project reference requires the specified member configuration deploy-arch-ibm-account-infra-base-abc123 to be deployed. Please deploy the referring configuration.
+      Code: 400
+      This is a valid reference that cannot be resolved until the member configuration is deployed.
+```
+
+**Cause**: This occurs when a reference points to a resource that will be created by a member configuration that hasn't been deployed yet. This is a normal part of the deployment process in multi-tier architectures.
+
+**Behavior**: The framework treats this as a warning, not an error. The test will continue and the reference will be resolved once the member configuration is deployed.
+
+**Solutions:**
+
+1. **Normal Operation**: This is expected behavior. The framework will proceed with deployment and the reference will resolve automatically.
+
+2. **If the reference fails during actual deployment**: This indicates a real issue with the reference configuration that needs to be addressed.
+
+3. **Skip reference validation** (for development/debugging):
+
+   ```golang
+   options.SkipRefValidation = true
+   ```

--- a/docs/projects/addons/validation-hooks.md
+++ b/docs/projects/addons/validation-hooks.md
@@ -69,6 +69,12 @@ options.SkipRefValidation = true
 - Automatically skips validation on known transient errors **only when infrastructure deployment is enabled**
 - **Validation-only mode**: When `SkipInfrastructureDeployment = true`, intermittent errors are NOT automatically skipped to ensure reference issues are caught
 
+**Special handling for member deployment references:**
+
+- References that require member configurations to be deployed first are treated as **warnings**, not errors
+- These are valid references that will resolve once the member configuration is deployed
+- The framework will proceed with deployment and the references will resolve automatically
+
 **When to skip:**
 
 - Known issues with reference resolution service (only in full deployment mode)

--- a/testaddons/tests_test.go
+++ b/testaddons/tests_test.go
@@ -1201,15 +1201,6 @@ func TestMissingConfigsErrorMessageFormat(t *testing.T) {
 // TestReferenceValidationMemberDeploymentWarning tests that references requiring member deployment
 // are treated as warnings rather than errors
 func TestReferenceValidationMemberDeploymentWarning(t *testing.T) {
-	// Create a mock test logger
-	logger := common.NewTestLogger(t.Name())
-
-	// Create test options with a mock CloudInfoService
-	options := &TestAddonOptions{
-		Testing:          t,
-		Logger:           logger,
-		CloudInfoService: &MockCloudInfoService{}, // We'll need to create this mock
-	}
 
 	// Create a mock resolve response that includes a member deployment reference
 	mockResolveResponse := &cloudinfo.ResolveResponse{


### PR DESCRIPTION
### Description

Some details where not getting populated in the dependency tree due to code to optimise the processing. This should fix it. 

Changed undeployed requirements to warning instead of error as it is an expected state. 

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
