### PR TITLE
Fix overriding dependency inputs addons

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-01T12:20:40Z",
+  "generated_at": "2025-09-24T22:21:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-24T22:21:14Z",
+  "generated_at": "2025-09-26T12:09:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -286,7 +286,7 @@
         "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 979,
+        "line_number": 981,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/docs/projects/addons/configuration.md
+++ b/docs/projects/addons/configuration.md
@@ -349,7 +349,7 @@ options.AddonConfig.Dependencies = []cloudinfo.AddonConfig{
 }
 ```
 
-**Note:** This can be used for direct and indirect dependencies. 
+**Note:** This can be used for direct and indirect dependencies.
 
 ### Dependency Configuration Options
 

--- a/docs/projects/addons/configuration.md
+++ b/docs/projects/addons/configuration.md
@@ -349,6 +349,8 @@ options.AddonConfig.Dependencies = []cloudinfo.AddonConfig{
 }
 ```
 
+**Note:** This can be used for direct and indirect dependencies. 
+
 ### Dependency Configuration Options
 
 ```golang

--- a/testaddons/tests.go
+++ b/testaddons/tests.go
@@ -356,86 +356,8 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 		}
 	}
 
-	// Process AddonConfig.Inputs with OverrideInputMappings logic for regular (non-matrix) tests
-	// This ensures input override logging and reference preservation works for both matrix and regular tests
-	if options.AddonConfig.Inputs != nil && len(options.AddonConfig.Inputs) > 0 {
-		// Apply the same reference-aware input processing logic as matrix tests
-		if options.OverrideInputMappings != nil && !*options.OverrideInputMappings {
-			// Reference preservation mode (default)
-			configReferences := options.configInputReferences[addonID]
-			preservedCount := 0
-			overriddenCount := 0
-
-			for inputKey, inputValue := range options.AddonConfig.Inputs {
-				if referenceValue, isReference := configReferences[inputKey]; isReference {
-					// Preserve reference value
-					if !options.QuietMode {
-						options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': preserving reference value '%s' (ignoring test override)", inputKey, referenceValue))
-					}
-					configDetails.Inputs[inputKey] = referenceValue
-					preservedCount++
-				} else {
-					// Override with new value
-					if !options.QuietMode {
-						existingValue := configDetails.Inputs[inputKey]
-						options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
-					}
-					configDetails.Inputs[inputKey] = inputValue
-					overriddenCount++
-				}
-			}
-
-			// Summary logging
-			if !options.QuietMode && (preservedCount > 0 || overriddenCount > 0) {
-				options.Logger.ShortInfo(fmt.Sprintf("Input merging complete: %d reference(s) preserved, %d input(s) overridden (OverrideInputMappings=false)", preservedCount, overriddenCount))
-			}
-		} else {
-			// Override all mode (legacy behavior)
-			overriddenCount := 0
-			if !options.QuietMode {
-				options.Logger.ShortInfo("Overriding ALL inputs (OverrideInputMappings=true)")
-			}
-
-			for inputKey, inputValue := range options.AddonConfig.Inputs {
-				if !options.QuietMode {
-					existingValue := configDetails.Inputs[inputKey]
-					options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
-				}
-				configDetails.Inputs[inputKey] = inputValue
-				overriddenCount++
-			}
-
-			if !options.QuietMode && overriddenCount > 0 {
-				options.Logger.ShortInfo(fmt.Sprintf("Input override complete: %d input(s) overridden (OverrideInputMappings=true)", overriddenCount))
-			}
-		}
-	}
-
-	confPatch := projectv1.ProjectConfigDefinitionPatch{
-		Inputs: configDetails.Inputs,
-		Authorizations: &projectv1.ProjectConfigAuth{
-			ApiKey: core.StringPtr(options.CloudInfoService.GetApiKey()),
-			Method: core.StringPtr(projectv1.ProjectConfigAuth_Method_ApiKey),
-		},
-	}
-	prjConfig, response, err := options.CloudInfoService.UpdateConfig(&configDetails, &confPatch)
-	if err != nil {
-		options.Logger.ShortError(fmt.Sprintf("Error updating the configuration: %v", err))
-		options.Logger.MarkFailed()
-		options.Logger.FlushOnFailure()
-		options.Testing.Fail()
-		return fmt.Errorf("error updating the configuration: %w", err)
-	}
-	if response.RawResult != nil {
-		options.Logger.ShortInfo(fmt.Sprintf("Response: %s", string(response.RawResult)))
-	}
-	options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration: %s", *prjConfig.ID))
-	if prjConfig.StateCode != nil {
-		options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration statecode: %s", *prjConfig.StateCode))
-	}
-	if prjConfig.State != nil {
-		options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration state: %s", *prjConfig.State))
-	}
+	mergeInputs(options, options.AddonConfig.Inputs, configDetails, addonID)
+	updateProjectConfiguration(options, configDetails)
 
 	// create TestProjectsOptions to use with the projects package
 	deployOptions := testprojects.TestProjectsOptions{
@@ -507,6 +429,10 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 			ProjectID: options.currentProjectConfig.ProjectID,
 			ConfigID:  *config.ID,
 		})
+		if err != nil {
+			options.Logger.ShortError(fmt.Sprintf("Failed to get configuration details: %v", err))
+			return setFailureResult(fmt.Errorf("failed to get configuration details: %w", err), "UPDATE_CONFIGURATION")
+		}
 
 		addonConfigDetails := cloudinfo.ConfigDetails{
 			ProjectID: options.currentProjectConfig.ProjectID,
@@ -518,96 +444,9 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 		// so we know which inputs need to be updated for the current configuration
 		for _, dep := range options.AddonConfig.Dependencies {
 			if dep.VersionLocator == *config.Definition.LocatorID {
-				// Process AddonConfig.Inputs with OverrideInputMappings logic for regular (non-matrix) tests
-				// This ensures input override logging and reference preservation works for both matrix and regular tests
-				if dep.Inputs != nil && len(dep.Inputs) > 0 {
-					// Apply the same reference-aware input processing logic as matrix tests
-					if options.OverrideInputMappings != nil && !*options.OverrideInputMappings {
-						// Reference preservation mode (default)
-						configReferences := options.configInputReferences[addonID]
-						preservedCount := 0
-						overriddenCount := 0
-
-						for inputKey, inputValue := range dep.Inputs {
-							if referenceValue, isReference := configReferences[inputKey]; isReference {
-								// Preserve reference value
-								if !options.QuietMode {
-									options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': preserving reference value '%s' (ignoring test override)", inputKey, referenceValue))
-								}
-								addonConfigDetails.Inputs[inputKey] = referenceValue
-								preservedCount++
-							} else {
-								// Override with new value
-								if !options.QuietMode {
-									existingValue := addonConfigDetails.Inputs[inputKey]
-									options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
-								}
-								addonConfigDetails.Inputs[inputKey] = inputValue
-								overriddenCount++
-							}
-						}
-
-						// Summary logging
-						if !options.QuietMode && (preservedCount > 0 || overriddenCount > 0) {
-							options.Logger.ShortInfo(fmt.Sprintf("Input merging complete: %d reference(s) preserved, %d input(s) overridden (OverrideInputMappings=false)", preservedCount, overriddenCount))
-						}
-					} else {
-						// Override all mode (legacy behavior)
-						overriddenCount := 0
-						if !options.QuietMode {
-							options.Logger.ShortInfo("Overriding ALL inputs (OverrideInputMappings=true)")
-						}
-
-						for inputKey, inputValue := range options.AddonConfig.Inputs {
-							if !options.QuietMode {
-								existingValue := addonConfigDetails.Inputs[inputKey]
-								options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
-							}
-							addonConfigDetails.Inputs[inputKey] = inputValue
-							overriddenCount++
-						}
-
-						if !options.QuietMode && overriddenCount > 0 {
-							options.Logger.ShortInfo(fmt.Sprintf("Input override complete: %d input(s) overridden (OverrideInputMappings=true)", overriddenCount))
-						}
-					}
-				}
-
+				mergeInputs(options, dep.Inputs, addonConfigDetails, addonID)
+				updateProjectConfiguration(options, addonConfigDetails)
 			}
-		}
-
-		confPatch := projectv1.ProjectConfigDefinitionPatch{
-			Inputs: currentConfigDetails.Definition.(*projectv1.ProjectConfigDefinitionResponse).Inputs,
-			Authorizations: &projectv1.ProjectConfigAuth{
-				ApiKey: core.StringPtr(options.CloudInfoService.GetApiKey()),
-				Method: core.StringPtr(projectv1.ProjectConfigAuth_Method_ApiKey),
-			},
-		}
-		addonConfig, response, err := options.CloudInfoService.UpdateConfig(&addonConfigDetails, &confPatch)
-		if err != nil {
-			options.Logger.ShortError(fmt.Sprintf("Error updating the configuration: %v", err))
-			options.Logger.MarkFailed()
-			options.Logger.FlushOnFailure()
-			options.Testing.Fail()
-			return fmt.Errorf("error updating the configuration: %w", err)
-		}
-		if response.RawResult != nil {
-			options.Logger.ShortInfo(fmt.Sprintf("Response: %s", string(response.RawResult)))
-		}
-		options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration: %s", *addonConfig.ID))
-		if addonConfig.StateCode != nil {
-			options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration statecode: %s", *addonConfig.StateCode))
-		}
-		if addonConfig.State != nil {
-			options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration state: %s", *addonConfig.State))
-		}
-
-		if err != nil {
-			options.Logger.ShortError(fmt.Sprintf("Error getting the configuration: %v", err))
-			options.Logger.MarkFailed()
-			options.Logger.FlushOnFailure()
-			options.Testing.Fail()
-			return fmt.Errorf("error getting the configuration: %w", err)
 		}
 
 		// Initialize reference cache if needed
@@ -3754,4 +3593,90 @@ func (options *TestAddonOptions) displaySingleTestStrictModeWarnings() {
 
 		options.Logger.ProgressInfo("")
 	}
+}
+
+func mergeInputs(options *TestAddonOptions, inputs map[string]interface{}, configDetails cloudinfo.ConfigDetails, addonID string) {
+	// Process AddonConfig.Inputs with OverrideInputMappings logic for regular (non-matrix) tests
+	// This ensures input override logging and reference preservation works for both matrix and regular tests
+	if inputs != nil && len(inputs) > 0 {
+		// Apply the same reference-aware input processing logic as matrix tests
+		if options.OverrideInputMappings != nil && !*options.OverrideInputMappings {
+			// Reference preservation mode (default)
+			configReferences := options.configInputReferences[addonID]
+			preservedCount := 0
+			overriddenCount := 0
+
+			for inputKey, inputValue := range inputs {
+				if referenceValue, isReference := configReferences[inputKey]; isReference {
+					// Preserve reference value
+					if !options.QuietMode {
+						options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': preserving reference value '%s' (ignoring test override)", inputKey, referenceValue))
+					}
+					configDetails.Inputs[inputKey] = referenceValue
+					preservedCount++
+				} else {
+					// Override with new value
+					if !options.QuietMode {
+						existingValue := configDetails.Inputs[inputKey]
+						options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
+					}
+					configDetails.Inputs[inputKey] = inputValue
+					overriddenCount++
+				}
+			}
+
+			// Summary logging
+			if !options.QuietMode && (preservedCount > 0 || overriddenCount > 0) {
+				options.Logger.ShortInfo(fmt.Sprintf("Input merging complete: %d reference(s) preserved, %d input(s) overridden (OverrideInputMappings=false)", preservedCount, overriddenCount))
+			}
+		} else {
+			// Override all mode (legacy behavior)
+			overriddenCount := 0
+			if !options.QuietMode {
+				options.Logger.ShortInfo("Overriding ALL inputs (OverrideInputMappings=true)")
+			}
+
+			for inputKey, inputValue := range options.AddonConfig.Inputs {
+				if !options.QuietMode {
+					existingValue := configDetails.Inputs[inputKey]
+					options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))
+				}
+				configDetails.Inputs[inputKey] = inputValue
+				overriddenCount++
+			}
+
+			if !options.QuietMode && overriddenCount > 0 {
+				options.Logger.ShortInfo(fmt.Sprintf("Input override complete: %d input(s) overridden (OverrideInputMappings=true)", overriddenCount))
+			}
+		}
+	}
+}
+
+func updateProjectConfiguration(options *TestAddonOptions, configDetails cloudinfo.ConfigDetails) error {
+	confPatch := projectv1.ProjectConfigDefinitionPatch{
+		Inputs: configDetails.Inputs,
+		Authorizations: &projectv1.ProjectConfigAuth{
+			ApiKey: core.StringPtr(options.CloudInfoService.GetApiKey()),
+			Method: core.StringPtr(projectv1.ProjectConfigAuth_Method_ApiKey),
+		},
+	}
+	prjConfig, response, err := options.CloudInfoService.UpdateConfig(&configDetails, &confPatch)
+	if err != nil {
+		options.Logger.ShortError(fmt.Sprintf("Error updating the configuration: %v", err))
+		options.Logger.MarkFailed()
+		options.Logger.FlushOnFailure()
+		options.Testing.Fail()
+		return fmt.Errorf("error updating the configuration: %w", err)
+	}
+	if response.RawResult != nil {
+		options.Logger.ShortInfo(fmt.Sprintf("Response: %s", string(response.RawResult)))
+	}
+	options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration: %s", *prjConfig.ID))
+	if prjConfig.StateCode != nil {
+		options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration statecode: %s", *prjConfig.StateCode))
+	}
+	if prjConfig.State != nil {
+		options.Logger.ShortInfo(fmt.Sprintf("Updated Configuration state: %s", *prjConfig.State))
+	}
+	return nil
 }

--- a/testaddons/tests.go
+++ b/testaddons/tests.go
@@ -356,6 +356,7 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 		}
 	}
 
+	// update main addon configuration with user defined inputs
 	mergeInputs(options, options.AddonConfig.Inputs, configDetails, addonID)
 	updateProjectConfiguration(options, configDetails)
 
@@ -440,9 +441,10 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 			Inputs:    currentConfigDetails.Definition.(*projectv1.ProjectConfigDefinitionResponse).Inputs,
 			ConfigID:  *config.ID,
 		}
-		// match dependency containing user inputs with project configuration returned by API
-		// so we know which inputs need to be updated for the current configuration
+
 		for _, dep := range options.AddonConfig.Dependencies {
+			// match dependency containing user inputs with project configuration returned by API
+			// so we know which inputs need to be updated for the current configuration
 			if dep.VersionLocator == *config.Definition.LocatorID {
 				mergeInputs(options, dep.Inputs, addonConfigDetails, addonID)
 				updateProjectConfiguration(options, addonConfigDetails)


### PR DESCRIPTION
### Description

for issue - https://github.ibm.com/GoldenEye/issues/issues/16169

Overriding dependency inputs addons was not working because we were not making calls to update dependency configurations. 

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
