### PR TITLE
fix OverrideInputMappings so that ref values can be overwritten

### DIFF
--- a/testaddons/tests.go
+++ b/testaddons/tests.go
@@ -3638,7 +3638,7 @@ func mergeInputs(options *TestAddonOptions, inputs map[string]interface{}, confi
 				options.Logger.ShortInfo("Overriding ALL inputs (OverrideInputMappings=true)")
 			}
 
-			for inputKey, inputValue := range options.AddonConfig.Inputs {
+			for inputKey, inputValue := range inputs {
 				if !options.QuietMode {
 					existingValue := configDetails.Inputs[inputKey]
 					options.Logger.ShortInfo(fmt.Sprintf("  Input '%s': %v → %v", inputKey, existingValue, inputValue))


### PR DESCRIPTION
### Description

for issue - https://github.ibm.com/GoldenEye/issues/issues/16233

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
