### PR TITLE
fix: allow HCL string defaults for array/object types in catalog validation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2025-09-26T12:09:12Z",
+  "generated_at": "2025-09-30T09:53:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -118,7 +118,7 @@
         "hashed_secret": "03e60e3e0d9675b19754e2a81bbb48a26af858e7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 914,
+        "line_number": 942,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/cloudinfo/projects_test.go
+++ b/cloudinfo/projects_test.go
@@ -1047,6 +1047,59 @@ func (suite *ProjectsServiceTestSuite) TestCreateStackFromConfigFile() {
 					"catalog configuration default value type mismatch in product 'Product Name', flavor 'Flavor Name': input2 expected type: int, got: string\n" +
 					"extra catalog input variable not found in stack definition in product 'Product Name', flavor 'Flavor Name': input5"),
 		},
+		{
+			name: "catalog with HCL string defaults for array/object types, should pass validation",
+			stackConfig: &ConfigDetails{
+				ProjectID: "mockProjectID",
+				ConfigID:  "54321",
+			},
+			stackConfigPath: "testdata/stack_definition_hcl_string_default.json",
+			catalogJsonPath: "testdata/ibm_catalog_hcl_string_default.json",
+			expectedConfig: &projects.StackDefinition{
+				ID: core.StringPtr("mockProjectID"),
+				StackDefinition: &projects.StackDefinitionBlock{
+					Inputs: []projects.StackDefinitionInputVariable{
+						{
+							Name:        core.StringPtr("config_object"),
+							Type:        core.StringPtr("object"),
+							Required:    core.BoolPtr(false),
+							Default:     core.StringPtr("{\n    setting1 = \"value1\"\n    setting2 = 42\n    nested   = {\n      key = \"value\"\n    }\n  }"),
+							Description: core.StringPtr(""),
+							Hidden:      core.BoolPtr(false),
+						},
+						{
+							Name:        core.StringPtr("region"),
+							Type:        core.StringPtr("string"),
+							Required:    core.BoolPtr(true),
+							Default:     core.StringPtr("us-south"),
+							Description: core.StringPtr(""),
+							Hidden:      core.BoolPtr(false),
+						},
+						{
+							Name:        core.StringPtr("secret_groups"),
+							Type:        core.StringPtr("array"),
+							Required:    core.BoolPtr(false),
+							Default:     core.StringPtr("[\n    {\n      secret_group_name        = \"General\"\n      secret_group_description = \"A general purpose secrets group with an associated access group which has a secrets reader role\"\n      create_access_group      = true\n      access_group_name        = \"general-secrets-group-access-group\"\n      access_group_roles       = [\"SecretsReader\"]\n    }\n  ]"),
+							Description: core.StringPtr(""),
+							Hidden:      core.BoolPtr(false),
+						},
+					},
+					Outputs: []projects.StackDefinitionOutputVariable{
+						{Name: core.StringPtr("output1"), Value: core.StringPtr("ref:../members/member1/outputs/output1")},
+					},
+					Members: []projects.StackDefinitionMember{
+						{
+							Name:           core.StringPtr("member1"),
+							VersionLocator: core.StringPtr("version1"),
+							Inputs: []projects.StackDefinitionMemberInput{
+								{Name: core.StringPtr("region"), Value: core.StringPtr("ref:../../inputs/region")},
+							},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cloudinfo/testdata/ibm_catalog_hcl_string_default.json
+++ b/cloudinfo/testdata/ibm_catalog_hcl_string_default.json
@@ -1,0 +1,64 @@
+{
+  "products": [
+    {
+      "label": "Product with HCL Defaults",
+      "name": "Product Name",
+      "product_kind": "solution",
+      "tags": ["test"],
+      "keywords": ["test"],
+      "short_description": "Test product with HCL string defaults",
+      "long_description": "Test product with HCL string defaults for array and object types",
+      "offering_docs_url": "http://example.com/docs",
+      "offering_icon_url": "http://example.com/icon",
+      "provider_name": "Test Provider",
+      "features": [],
+      "support_details": "Support details",
+      "flavors": [
+        {
+          "label": "Test Flavor",
+          "name": "Flavor Name",
+          "working_directory": ".",
+          "compliance": {
+            "authority": "scc-v3",
+            "profiles": []
+          },
+          "iam_permissions": [],
+          "architecture": {
+            "features": [],
+            "diagrams": []
+          },
+          "configuration": [
+            {
+              "key": "secret_groups",
+              "type": "array",
+              "description": "Secret groups configuration",
+              "default_value": "[\n    {\n      secret_group_name        = \"General\"\n      secret_group_description = \"A general purpose secrets group with an associated access group which has a secrets reader role\"\n      create_access_group      = true\n      access_group_name        = \"general-secrets-group-access-group\"\n      access_group_roles       = [\"SecretsReader\"]\n    }\n  ]",
+              "required": false
+            },
+            {
+              "key": "config_object",
+              "type": "object",
+              "description": "Configuration object",
+              "default_value": "{\n    setting1 = \"value1\"\n    setting2 = 42\n    nested   = {\n      key = \"value\"\n    }\n  }",
+              "required": false
+            },
+            {
+              "key": "region",
+              "type": "string",
+              "description": "IBM Cloud region",
+              "default_value": "us-south",
+              "required": true
+            }
+          ],
+          "outputs": [
+            {
+              "key": "output1",
+              "description": "Test output"
+            }
+          ],
+          "install_type": "fullstack"
+        }
+      ]
+    }
+  ]
+}

--- a/cloudinfo/testdata/ibm_catalog_with_config_overrides_value_type_mismatch.json
+++ b/cloudinfo/testdata/ibm_catalog_with_config_overrides_value_type_mismatch.json
@@ -78,7 +78,7 @@
               "key": "input3",
               "type": "array",
               "description": "Description for input3",
-              "default_value": "[\"catalog_arr_value1\", \"catalog_arr_value2\"]",
+              "default_value": "not_an_array_just_a_string",
               "required": true,
               "display_name": "Input 3"
             },

--- a/cloudinfo/testdata/stack_definition_hcl_string_default.json
+++ b/cloudinfo/testdata/stack_definition_hcl_string_default.json
@@ -1,0 +1,43 @@
+{
+  "inputs": [
+    {
+      "name": "secret_groups",
+      "required": false,
+      "type": "array",
+      "hidden": false,
+      "default": []
+    },
+    {
+      "name": "config_object",
+      "required": false,
+      "type": "object",
+      "hidden": false,
+      "default": {}
+    },
+    {
+      "name": "region",
+      "required": true,
+      "type": "string",
+      "hidden": false,
+      "default": "us-south"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "output1",
+      "value": "ref:../members/member1/outputs/output1"
+    }
+  ],
+  "members": [
+    {
+      "inputs": [
+        {
+          "name": "region",
+          "value": "ref:../../inputs/region"
+        }
+      ],
+      "name": "member1",
+      "version_locator": "version1"
+    }
+  ]
+}


### PR DESCRIPTION
### Description
https://github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/issues/1045

The validateCatalogInputsInStackDefinition function now accepts string default values containing HCL/Terraform code for array and object types. This is a common pattern in IBM Cloud catalog configurations.

- Add isStructuredDataString helper to detect HCL string representations
- Update validation logic to allow HCL strings for array/object types
- Add object type handling in updateInputsFromCatalog
- Add test case with HCL string defaults for array and object inputs

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
