### PR TITLE
feat: Addons test undeploys resources and keeps project on test failure

### DIFF
--- a/testaddons/setup_teardown.go
+++ b/testaddons/setup_teardown.go
@@ -373,9 +373,19 @@ func (options *TestAddonOptions) testTearDown() {
 	}
 
 	if options.executeResourceTearDown() {
-		options.RunPreUndeployHook()
-		options.Undeploy()
-		options.RunPostUndeployHook()
+		err := options.RunPreUndeployHook()
+		if err != nil {
+			options.Logger.ShortWarn(fmt.Sprintf("Pre Undeploy hook failed: %s", err))
+		}
+
+		err = options.Undeploy()
+		if err != nil {
+			options.Logger.ShortWarn(fmt.Sprintf("Undeploy resources failed: %s", err))
+			postHookErr := options.RunPostUndeployHook()
+			if postHookErr != nil {
+				options.Logger.ShortWarn(fmt.Sprintf("Post Undeploy hook failed: %s", postHookErr))
+			}
+		}
 	}
 
 	if options.executeProjectTearDown() {

--- a/testaddons/test_options.go
+++ b/testaddons/test_options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/cloudinfo"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/common"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testprojects"
 )
 
 const defaultRegion = "us-south"
@@ -430,6 +431,8 @@ type TestAddonOptions struct {
 	// Internal Use
 	// catalog the catalog instance in use.
 	catalog *catalogmanagementv1.Catalog
+
+	deployOptions testprojects.TestProjectsOptions
 
 	// internal use
 	// offering the offering created in the catalog.

--- a/testaddons/tests.go
+++ b/testaddons/tests.go
@@ -374,7 +374,7 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 	updateProjectConfiguration(options, configDetails)
 
 	// create TestProjectsOptions to use with the projects package
-	deployOptions := testprojects.TestProjectsOptions{
+	options.deployOptions = testprojects.TestProjectsOptions{
 		Prefix:               options.Prefix,
 		ProjectName:          options.ProjectName,
 		CloudInfoService:     options.CloudInfoService,
@@ -384,8 +384,8 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 		StackPollTimeSeconds: 60,
 	}
 
-	deployOptions.SetCurrentStackConfig(&configDetails)
-	deployOptions.SetCurrentProjectConfig(options.currentProjectConfig)
+	options.deployOptions.SetCurrentStackConfig(&configDetails)
+	options.deployOptions.SetCurrentProjectConfig(options.currentProjectConfig)
 
 	allConfigs, err := options.CloudInfoService.GetProjectConfigs(options.currentProjectConfig.ProjectID)
 	if err != nil {
@@ -1452,7 +1452,7 @@ func (options *TestAddonOptions) runAddonTest(enhancedReporting bool) error {
 		if options.QuietMode {
 			options.Logger.ProgressStage("Deploying infrastructure")
 		}
-		errorList := deployOptions.TriggerDeployAndWait()
+		errorList := options.deployOptions.TriggerDeployAndWait()
 		if len(errorList) > 0 {
 			options.Logger.ShortError("Errors occurred during infrastructure deployment")
 			options.Logger.ShortError("Note: IBM Cloud Projects workflow requires successful validation (terraform plan) before deployment (terraform apply)")
@@ -1548,23 +1548,12 @@ func (options *TestAddonOptions) RunPreUndeployHook() error {
 }
 
 func (options *TestAddonOptions) Undeploy() error {
-	// create TestProjectsOptions to use with the projects package
-	deployOptions := testprojects.TestProjectsOptions{
-		Prefix:               options.Prefix,
-		ProjectName:          options.ProjectName,
-		CloudInfoService:     options.CloudInfoService,
-		Logger:               options.Logger.GetUnderlyingLogger(),
-		Testing:              options.Testing,
-		DeployTimeoutMinutes: options.DeployTimeoutMinutes,
-		StackPollTimeSeconds: 60,
-	}
-
 	// Trigger Undeploy
 	if !options.SkipInfrastructureDeployment {
 		if options.QuietMode {
 			options.Logger.ProgressStage("Cleaning up infrastructure")
 		}
-		undeployErrs := deployOptions.TriggerUnDeployAndWait()
+		undeployErrs := options.deployOptions.TriggerUnDeployAndWait()
 		if len(undeployErrs) > 0 {
 			options.Logger.ShortError("Errors occurred during undeploy")
 			for _, err := range undeployErrs {


### PR DESCRIPTION
### Description

Addons test undeploys resources and keeps project on test failure

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
